### PR TITLE
Require an older version of yaenv in order to loosen up dependency constraints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license = 'MIT License',
     install_requires = [
         'GitPython == 3.1.11',
-        'yaenv == 1.4.1'
+        'yaenv == 1.2.2'
    ],
    keywords = ['BINBASH', 'LEVERAGE'],
    classifiers = [


### PR DESCRIPTION
This should help when installing Leverage CLI on Python versions older than 3.8. For instance, 3.6 is the default Ubuntu 18.04.