### PR TITLE
Get version for test publish from input

### DIFF
--- a/.github/workflows/build-push-test-package.yml
+++ b/.github/workflows/build-push-test-package.yml
@@ -2,6 +2,10 @@ name: Test Build Package and Push
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish:"
+        required: true
 
 jobs:
   build_push:
@@ -18,28 +22,15 @@ jobs:
 
       - name: bump_version
         run: |
-          echo "[INFO] Get latest tag"
-          git fetch --all --tags
-          RELEASE_VERSION=$(git tag | tail -1)
-          RELEASE_VERSION=$(echo $RELEASE_VERSION | sed s/v//)
-          echo $RELEASE_VERSION
-
           echo "[INFO] Get current version"
           CURRENT_VERSION=$(cat $INIT_FILE | grep "__version__" | grep -oP "([0-9]*\.[0-9]*\.[0-9]*)")
           echo $CURRENT_VERSION
 
-          echo "[INFO] Bump version"
+          echo "[INFO] Bump version to $RELEASE_VERSION"
           sed -i s/$CURRENT_VERSION/$RELEASE_VERSION/ $INIT_FILE
-
-          echo "[INFO] Commit and push"
-          git config user.name $GIT_USERNAME
-          git config user.email $GIT_EMAIL
-          git add $INIT_FILE
-          git commit -m "Bump version from $CURRENT_VERSION to $RELEASE_VERSION"
         env:
           INIT_FILE: leverage/__init__.py
-          GIT_USERNAME: ${{ secrets.GIT_USERNAME }}
-          GIT_EMAIL: ${{ secrets.GIT_EMAIL }}
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
 
       - name: clean
         run: |

--- a/.github/workflows/build-push-test-package.yml
+++ b/.github/workflows/build-push-test-package.yml
@@ -4,8 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish:"
-        required: true
+        description: |
+          "Version to publish (optional):
+          If not given, next patch from latest will be used."
+        default: ""
+        required: false
 
 jobs:
   build_push:
@@ -25,6 +28,10 @@ jobs:
           echo "[INFO] Get current version"
           CURRENT_VERSION=$(cat $INIT_FILE | grep "__version__" | grep -oP "([0-9]*\.[0-9]*\.[0-9]*)")
           echo $CURRENT_VERSION
+
+          [ -z "$RELEASE_VERSION" ] && \
+            LATEST_VERSION=$(curl -sL "https://test.pypi.org/pypi/leverage/json" | jq ".releases | keys | sort | .[-1]") && \
+            RELEASE_VERSION=$(echo ${LATEST_VERSION:1:-1} | awk 'BEGIN{FS="."; OFS="."} {print $1,$2,$3+1}')
 
           echo "[INFO] Bump version to $RELEASE_VERSION"
           sed -i s/$CURRENT_VERSION/$RELEASE_VERSION/ $INIT_FILE

--- a/.github/workflows/build-push-test-package.yml
+++ b/.github/workflows/build-push-test-package.yml
@@ -27,11 +27,13 @@ jobs:
         run: |
           echo "[INFO] Get current version"
           CURRENT_VERSION=$(cat $INIT_FILE | grep "__version__" | grep -oP "([0-9]*\.[0-9]*\.[0-9]*)")
-          echo $CURRENT_VERSION
+          echo "[INFO] Current version: $CURRENT_VERSION"
 
           [ -z "$RELEASE_VERSION" ] && \
-            LATEST_VERSION=$(curl -sL "https://test.pypi.org/pypi/leverage/json" | jq ".releases | keys | sort | .[-1]") && \
-            RELEASE_VERSION=$(echo ${LATEST_VERSION:1:-1} | awk 'BEGIN{FS="."; OFS="."} {print $1,$2,$3+1}')
+            echo "[INFO] Get latest version from TestPypi." && \
+            LATEST_VERSION=$(curl -sL "https://test.pypi.org/pypi/leverage/json" | jq -r ".releases | keys | sort | .[-1]") && \
+            echo "[INFO] Latest version: $LATEST_VERSION" && \
+            RELEASE_VERSION=$(echo $LATEST_VERSION | awk 'BEGIN{FS="."; OFS="."} {print $1,$2,$3+1}')
 
           echo "[INFO] Bump version to $RELEASE_VERSION"
           sed -i s/$CURRENT_VERSION/$RELEASE_VERSION/ $INIT_FILE

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -26,7 +26,7 @@ LEVERAGE_DIR = Path.home() / ".leverage"
 TEMPLATE_DIR = LEVERAGE_DIR / "template"
 TEMPLATE_PATTERN = "*.template"
 LEVERAGE_TEMPLATE_REPO = "https://github.com/binbashar/le-tf-infra-aws-template.git"
-IGNORE_PATTERNS = ignore_patterns(TEMPLATE_PATTERN, ".gitkeep")
+IGNORE_PATTERNS = ignore_patterns([TEMPLATE_PATTERN, ".gitkeep"])
 
 # Useful project related definitions
 try:

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -19,6 +19,7 @@ from leverage import logger
 from leverage.path import get_root_path
 from leverage.path import NotARepositoryError
 
+from leverage.modules.terraform import format as _format
 
 # Leverage related base definitions
 # NOTE: Should LEVERAGE_DIR be a bit more platform agnostic?
@@ -232,7 +233,8 @@ def _render_project_template(config, source=TEMPLATE_DIR):
 
 
 @project.command()
-def create():
+@click.pass_context
+def create(context):
     """ Create the directory structure required by the project configuration and set up each account accordingly. """
 
     # Load project configuration file
@@ -252,3 +254,9 @@ def create():
 
     # Render project
     _render_project_template(config=config)
+
+    # Format the code correctly
+    logger.info("Reformatting terraform configuration to the standard style.")
+    context.invoke(_format)
+
+    logger.info("Finished setting up project.")

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -26,7 +26,7 @@ LEVERAGE_DIR = Path.home() / ".leverage"
 TEMPLATE_DIR = LEVERAGE_DIR / "template"
 TEMPLATE_PATTERN = "*.template"
 LEVERAGE_TEMPLATE_REPO = "https://github.com/binbashar/le-tf-infra-aws-template.git"
-IGNORE_PATTERNS = ignore_patterns([TEMPLATE_PATTERN, ".gitkeep"])
+IGNORE_PATTERNS = ignore_patterns(TEMPLATE_PATTERN, ".gitkeep")
 
 # Useful project related definitions
 try:

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -19,7 +19,6 @@ from leverage import logger
 from leverage.path import get_root_path
 from leverage.path import NotARepositoryError
 
-from leverage.modules.terraform import format as _format
 
 # Leverage related base definitions
 # NOTE: Should LEVERAGE_DIR be a bit more platform agnostic?
@@ -233,8 +232,7 @@ def _render_project_template(config, source=TEMPLATE_DIR):
 
 
 @project.command()
-@click.pass_context
-def create(context):
+def create():
     """ Create the directory structure required by the project configuration and set up each account accordingly. """
 
     # Load project configuration file
@@ -254,9 +252,3 @@ def create(context):
 
     # Render project
     _render_project_template(config=config)
-
-    # Format the code correctly
-    logger.info("Reformatting terraform configuration to the standard style.")
-    context.invoke(_format)
-
-    logger.info("Finished setting up project.")


### PR DESCRIPTION
## What
 - Allow `build_push_test_package` to get the version to publish from user input. If no version to publish is provided then the latest published version is fetched form TestPypi and the next patch from that is used.

## Why
Allows for greater flexibility when it comes to quickly test published packages.