### PR TITLE
Feature | Pull docker image from registry for testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,9 +1,9 @@
-name: Run unit tests 
+name: Run tests 
 
 on: [pull_request]
 
 jobs:
-  run_unit_tests:
+  unit_tests:
     runs-on: ubuntu-latest 
     steps:
       - uses: actions/checkout@v2
@@ -12,9 +12,6 @@ jobs:
 
       - name: run_unit_tests
         run: |
-          echo "[INFO] Building image"
-          make build-image
-
           echo "[INFO] Running unit tests"
           make test-unit-no-cov
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,22 @@
 .PHONY: help build
 LEVERAGE_TESTING_IMAGE := binbash/leverage-cli-testing
+LEVERAGE_TESTING_TAG   := 1.0.0
 
 help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
 build-image: ## Build docker image
-	docker build . -t ${LEVERAGE_TESTING_IMAGE}
+	docker build . -t ${LEVERAGE_TESTING_IMAGE}:${LEVERAGE_TESTING_TAG}
 
 test-unit: ## Run unit tests and create a coverage report
-	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE} -c "pytest --verbose"
+	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE}:${LEVERAGE_TESTING_TAG} -c "pytest --verbose"
 
 test-unit-no-cov: ## Run unit tests with no coverage report
-	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE} -c "pytest --verbose --no-cov"
+	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE}:${LEVERAGE_TESTING_TAG} -c "pytest --verbose --no-cov"
 
 test-int: ## Run integration tests
-	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE} bats -r tests/bats
+	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE}:${LEVERAGE_TESTING_TAG} bats -r tests/bats
 
 tests: test-unit-no-cov test-int ## Run full set of tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
 .PHONY: help build
+LEVERAGE_TESTING_IMAGE := binbash/leverage-cli-testing
 
 help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
 build-image: ## Build docker image
-	docker build . -t leverage-testing
+	docker build . -t ${LEVERAGE_TESTING_IMAGE}
 
 test-unit: ## Run unit tests and create a coverage report
-	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t leverage-testing -c "pytest --verbose"
+	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE} -c "pytest --verbose"
 
 test-unit-no-cov: ## Run unit tests with no coverage report
-	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t leverage-testing -c "pytest --verbose --no-cov"
+	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE} -c "pytest --verbose --no-cov"
 
 test-int: ## Run integration tests
-	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t leverage-testing bats -r tests/bats
+	docker run --rm --mount type=bind,src=$(shell pwd),dst=/leverage -t ${LEVERAGE_TESTING_IMAGE} bats -r tests/bats
 
 tests: test-unit-no-cov test-int ## Run full set of tests
 
@@ -36,6 +37,3 @@ push: ## Push distributables to PyPi
 
 push-test: ## Push distributables to Pypi test
 	pipenv run twine upload --repository testpypi dist/*
-
-install-command: ## Command for installing leverage as a local package for development in a leverage ref arch project
-	@echo 'python3 -m pip3 install pipenv && pipenv install -e $(shell pwd)'

--- a/tests/bats/no_git_leverage.bats
+++ b/tests/bats/no_git_leverage.bats
@@ -1,20 +1,18 @@
 # The name of the file was chosen as to avoid repetition of the leverage package installing step
 # in leverage.bats, since bats respects file name order to run the tests
 
-setup_file(){
-    # Uninstall git
-    apt-get remove -y git >/dev/null 2>&1
-}
-
-teardown_file(){
-    # Reinstall git
-    apt-get install -y git >/dev/null 2>&1
-}
-
 setup(){
     # Bats modules are installed globally
     load "/usr/lib/node_modules/bats-support/load.bash"
     load "/usr/lib/node_modules/bats-assert/load.bash"
+
+    # Uninstall git
+    apt-get remove -y git >/dev/null 2>&1
+}
+
+teardown(){
+    # Reinstall git
+    apt-get install -y git >/dev/null 2>&1
 }
 
 @test "Does not run if git is not installed in the system" {


### PR DESCRIPTION
## What?
* Modify Makefile to pull docker image from registry instead of building it when running tests
* Simplify unit testing workflow to reduce time consumption in actions
* Fix a bats test

## References
* Closes #45 