### PR TITLE
Fix | Update local template instead of skipping when initializing a project

### DIFF
--- a/leverage/_utils.py
+++ b/leverage/_utils.py
@@ -1,6 +1,8 @@
 """
     General use utilities.
 """
+from subprocess import run
+from subprocess import PIPE
 
 def clean_exception_traceback(exception):
     """ Delete special local variables from all frames of an exception's traceback
@@ -36,3 +38,15 @@ def clean_exception_traceback(exception):
         traceback = traceback.tb_next
 
     return exception
+
+
+def git(command):
+    """ Run the given git command.
+
+    Args:
+        command (str): Complete git command with or without the binary name.
+    """
+    command = command.split()
+    command = ["git"] + command if command[0] != "git" else command
+
+    run(command, stdout=PIPE, stderr=PIPE, check=True)

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -1,13 +1,10 @@
 """
     Module for managing Leverage projects.
 """
-import re
 from pathlib import Path
 from shutil import copy2
 from shutil import copytree
 from shutil import ignore_patterns
-from subprocess import run
-from subprocess import PIPE
 
 import click
 from click.exceptions import Exit
@@ -19,6 +16,7 @@ from leverage import logger
 from leverage.logger import console
 from leverage.path import get_root_path
 from leverage.path import NotARepositoryError
+from leverage._utils import git
 
 from leverage.modules.terraform import run as tfrun
 
@@ -94,13 +92,18 @@ def init():
 
     if not (TEMPLATE_DIR / ".git").exists():
         logger.info("No project template found. Cloning template.")
-        run(["git", "clone", LEVERAGE_TEMPLATE_REPO, TEMPLATE_DIR.as_posix()],
-            stdout=PIPE, stderr=PIPE, check=True)
+        git(f"clone {LEVERAGE_TEMPLATE_REPO} {TEMPLATE_DIR.as_posix()}")
         logger.info("Finished cloning template.")
+
+    else:
+        logger.info("Project template found. Updating.")
+        git(f"-C {TEMPLATE_DIR.as_posix()} checkout master")
+        git(f"-C {TEMPLATE_DIR.as_posix()} pull")
+        logger.info("Finished updating template.")
 
     # Leverage projects are git repositories too
     logger.info("Initializing git repository in project directory.")
-    run(["git", "init"], stdout=PIPE, stderr=PIPE, check=True)
+    git("init")
 
     # Project configuration file
     if not PROJECT_CONFIG.exists():


### PR DESCRIPTION
## What?
* Upon project initialization if the template is already found pull instead of skipping to next task, to keep it up to date.

## Why?
* An out-of-date local version of the template can cause issues when rendering a new project

## References
* closes #57 

