### PR TITLE
Fix | `terraform` commands

### DIFF
--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -28,6 +28,7 @@ from leverage.path import NotARepositoryError
 
 # Terraform image definitions
 TERRAFORM_IMAGE = "binbash/terraform-awscli-slim"
+DEFAULT_IMAGE_TAG = "1.0.9"
 TERRAFORM_BINARY = "/bin/terraform"
 TERRAFORM_MFA_ENTRYPOINT = "/root/scripts/aws-mfa/aws-mfa-entrypoint.sh"
 WORKING_DIR = "/go/src/project"
@@ -143,7 +144,7 @@ def run(entrypoint=None, command="", args=None, enable_mfa=True, interactive=Tru
     if not aws_credentials_directory.exists():
         aws_credentials_directory.mkdir(parents=True)
 
-    terraform_image_tag = env.get("TERRAFORM_IMAGE_TAG", "latest")
+    terraform_image_tag = env.get("TERRAFORM_IMAGE_TAG", DEFAULT_IMAGE_TAG)
     ensure_image(docker_client=docker_client,
                  image=TERRAFORM_IMAGE,
                  tag=terraform_image_tag)

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -282,7 +282,7 @@ def apply(args):
 @check_directory
 def output(args):
     """ Show all output variables of this layer. """
-    run(command="output", args=list(args), enable_mfa=False)
+    run(command="output", args=list(args))
 
 
 @terraform.command(context_settings=CONTEXT_SETTINGS)


### PR DESCRIPTION
## What?
* Add the required mounted volumes and environment variables to the terraform container to be able to run MFA script when in shell.
* Pin terraform image tag to `1.0.9` as a safe default instead of `latest` as it previously was.
* Allow terraform output to take the MFA configuration from env file instead of it being always disabled
* Improve container entrypoint setting logic for MFA-enabled commands. Now these are only run in layer directories and never reach the MFA script when they are being execute elsewhere.

## References
* closes #61 
* closes #60 

