### PR TITLE
Fix | `credentials` commands

### DIFF
--- a/leverage/conf.py
+++ b/leverage/conf.py
@@ -10,7 +10,10 @@ from leverage.path import get_root_path
 from leverage.path import get_working_path
 
 
-def load(config_filename="build.env"):
+ENV_CONFIG_FILE = "build.env"
+
+
+def load(config_filename=ENV_CONFIG_FILE):
     """ Load all .env files with the given name in the current directory an all of its parents up to
     the repository root directory and store them in a dictionary.
     Files are traversed from parent to child as to allow values in deeper directories to override possible

--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -177,14 +177,14 @@ def _ask_for_credentials_location():
             "message": "Path to access keys file:",
             "qmark": ">",
             "when": lambda qs: qs["input_type"] == "path",
-            "validate": lambda value: (Path(value).is_file() and Path(value).exists()) or "Path must be an existing file"
+            "validate": lambda value: (Path(value).expanduser().is_file() and Path(value).expanduser().exists()) or "Path must be an existing file"
         }
     ])
     if not location:
         return
 
     input_type = location.get("input_type")
-    return Path(location.get("path")) if input_type == "path" else input_type
+    return Path(location.get("path")).expanduser() if input_type == "path" else input_type
 
 
 @_exit_if_user_cancels_input

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -270,6 +270,7 @@ def load_project_config():
         dict:  Project configuration.
     """
     if not PROJECT_CONFIG.exists():
+        logger.debug("No project config file found.")
         return {}
 
     try:
@@ -309,19 +310,21 @@ def create():
     logger.info("Finished setting up project.")
 
 
-def render_file(file):
+def render_file(file, config=None):
     """ Utility to re-render specific files.
 
     Args:
         file (str): Relative path to file to render.
+        config (dict, optional): Config used to render file.
 
     Returns:
         bool: Whether the action succeeded or not
     """
-    # TODO: Make use of internal state
-    config = load_project_config()
     if not config:
-        return False
+        # TODO: Make use of internal state
+        config = load_project_config()
+        if not config:
+            return False
 
     try:
         _render_templates([TEMPLATE_DIR / f"{file}.template"], config=config)


### PR DESCRIPTION
## What?
* AWS access keys files are now parsed as csv to extract the credentials
* Relative paths to `$HOME` are now allowed for providing access keys files locations
* Registering `security` credentials no longer errors out (the wrong set of credentials were being used for getting organization accounts)
* `project.yaml` and `build.env` files are no longer essential for the commands, a more complex logic to obtain the required information was implemented

## References
* closes #58 
* closes #56 
* closes #55 

