### PR TITLE
Fix | Mount AWS credentials correctly for Terraform commands

### DIFF
--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -16,6 +16,7 @@ from ruamel.yaml import YAML
 from leverage import logger
 from leverage.path import get_home_path
 from leverage.path import get_global_config_path
+from leverage.path import NotARepositoryError
 from leverage._internals import pass_state
 from leverage.modules.terraform import awscli
 from leverage.modules.terraform import run as tfrun
@@ -41,8 +42,12 @@ MFA_SERIAL = fr"arn:aws:iam::{ACCOUNT_ID}:mfa/{USERNAME}"
 # Regex for extracting project short name
 TFVARS_SHORT_NAME = fr"\s*project\s*=\s*\"(?P<project_short>{PROJECT_SHORT})\"\s*"
 
-AWSCLI_CONFIG_DIR = Path(get_home_path()) / ".aws"
-PROJECT_COMMON_TFVARS = Path(get_global_config_path()) / "common.tfvars"
+# TODO: Remove these and get them into the global app state
+try:
+    AWSCLI_CONFIG_DIR = Path(get_home_path()) / ".aws"
+    PROJECT_COMMON_TFVARS = Path(get_global_config_path()) / "common.tfvars"
+except NotARepositoryError:
+    AWSCLI_CONFIG_DIR = PROJECT_COMMON_TFVARS = ""
 
 PROFILES = {
     "bootstrap": {

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -31,7 +31,6 @@ TERRAFORM_IMAGE = "binbash/terraform-awscli-slim"
 DEFAULT_IMAGE_TAG = "1.0.9"
 TERRAFORM_BINARY = "/bin/terraform"
 TERRAFORM_MFA_ENTRYPOINT = "/root/scripts/aws-mfa/aws-mfa-entrypoint.sh"
-TERRAFORM_NON_MFA_ENTRYPOINT = "/root/scripts/aws-mfa/aws-non-mfa-entrypoint.sh"
 WORKING_DIR = "/go/src/project"
 
 CWD = get_working_path()
@@ -154,7 +153,8 @@ def run(entrypoint=TERRAFORM_BINARY, command="", args=None, enable_mfa=True, int
         Mount(target=WORKING_DIR, source=CWD, type="bind"),
         Mount(target="/root/.ssh", source=f"{HOME}/.ssh", type="bind"),
         Mount(target="/etc/gitconfig", source=f"{HOME}/.gitconfig", type="bind"),
-        Mount(target=f"/root/tmp/{project}", source=f"{HOME}/.aws/{project}", type="bind")
+        Mount(target=f"/root/tmp/{project}", source=f"{HOME}/.aws/{project}", type="bind"),
+        Mount(target=f"/root/.aws/{project}", source=f"{HOME}/.aws/{project}", type="bind")
     ]
     if Path(str(CONFIG)).exists() and Path(str(ACCOUNT_CONFIG)).exists():
         mounts.extend([
@@ -167,7 +167,6 @@ def run(entrypoint=TERRAFORM_BINARY, command="", args=None, enable_mfa=True, int
         "AWS_CONFIG_FILE": f"/root/.aws/{project}/config",
         "BACKEND_CONFIG_FILE": BACKEND_TFVARS,
         "COMMON_CONFIG_FILE": COMMON_TFVARS,
-        "SRC_AWS_DIR": f"/root/tmp/{project}",
         "SRC_AWS_CONFIG_FILE": f"/root/tmp/{project}/config",
         "SRC_AWS_SHARED_CREDENTIALS_FILE": f"/root/tmp/{project}/credentials",
         "AWS_CACHE_DIR": f"/root/tmp/{project}/cache",
@@ -184,9 +183,6 @@ def run(entrypoint=TERRAFORM_BINARY, command="", args=None, enable_mfa=True, int
             entrypoint = f"{TERRAFORM_MFA_ENTRYPOINT} -- {entrypoint}"
         else:
             entrypoint = TERRAFORM_MFA_ENTRYPOINT
-    
-    else:
-        entrypoint = f"{TERRAFORM_NON_MFA_ENTRYPOINT} -- {entrypoint}"
 
     args = [] if args is None else args
     command = " ".join([command] + args)

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -153,8 +153,7 @@ def run(entrypoint=TERRAFORM_BINARY, command="", args=None, enable_mfa=True, int
         Mount(target=WORKING_DIR, source=CWD, type="bind"),
         Mount(target="/root/.ssh", source=f"{HOME}/.ssh", type="bind"),
         Mount(target="/etc/gitconfig", source=f"{HOME}/.gitconfig", type="bind"),
-        Mount(target=f"/root/tmp/{project}", source=f"{HOME}/.aws/{project}", type="bind"),
-        Mount(target=f"/root/.aws/{project}", source=f"{HOME}/.aws/{project}", type="bind")
+        Mount(target=f"/root/tmp/{project}", source=f"{HOME}/.aws/{project}", type="bind")
     ]
     if Path(str(CONFIG)).exists() and Path(str(ACCOUNT_CONFIG)).exists():
         mounts.extend([
@@ -185,6 +184,12 @@ def run(entrypoint=TERRAFORM_BINARY, command="", args=None, enable_mfa=True, int
             entrypoint = f"{TERRAFORM_MFA_ENTRYPOINT} -- {entrypoint}"
         else:
             entrypoint = TERRAFORM_MFA_ENTRYPOINT
+    
+    else:
+        environment.update({
+            "AWS_CONFIG_FILE": f"/root/tmp/{project}/config",
+            "AWS_SHARED_CREDENTIALS_FILE": f"/root/tmp/{project}/credentials"
+        })
 
     args = [] if args is None else args
     command = " ".join([command] + args)

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -173,7 +173,9 @@ def run(entrypoint=TERRAFORM_BINARY, command="", args=None, enable_mfa=True, int
         "MFA_SCRIPT_LOG_LEVEL": get_mfa_script_log_level()
     }
     
-    enable_mfa = enable_mfa and env.get("MFA_ENABLED") == "true"
+    if entrypoint == TERRAFORM_BINARY:
+        enable_mfa = enable_mfa and env.get("MFA_ENABLED") == "true"
+
     if enable_mfa:
         if Path(CWD).parents[1] != Path(ACCOUNT):
             logger.error("This command can only run at [bold]layer[/bold] level.")
@@ -328,11 +330,7 @@ def _import(address, _id):
 
 
 @terraform.command(context_settings=CONTEXT_SETTINGS)
-@click.option("--no-mfa",
-              is_flag=True,
-              default=False,
-              help="Disable MFA.")
 @click.argument("args", nargs=-1)
-def aws(no_mfa, args):
+def aws(args):
     """ Run a command in AWS cli. """
-    run(entrypoint="/usr/bin/aws", args=list(args), enable_mfa=not no_mfa)
+    run(entrypoint="/usr/bin/aws", args=list(args), enable_mfa=False)

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -307,9 +307,13 @@ def version():
 
 
 @terraform.command()
-def shell():
+@click.option("--mfa",
+              is_flag=True,
+              default=False,
+              help="Enable Multi Factor Authentication upon launching shell.")
+def shell(mfa):
     """ Open a shell into the Terraform container in this layer. """
-    run(entrypoint="/bin/sh", enable_mfa=False)
+    run(entrypoint="/bin/sh", enable_mfa=mfa)
 
 
 @terraform.command("format")


### PR DESCRIPTION
## What?
* Change mounted volumes in terraform container as to avoid issues with AWS credentials when running MFA script
* Add defaults to values in credentials module that were causing issues when running in an uninitialized project