### PR TITLE
Enhancement | Prevent credentials command from overriding already configured values

### DIFF
--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -480,7 +480,7 @@ def configure_accounts_profiles(profile, region, organization_accounts, project_
     """
     short_name, type = profile.split("-")
 
-    mfa_serial = None
+    mfa_serial = ""
     if PROFILES[type]["mfa"]:
         logger.info("Fetching MFA device serial.")
         mfa_serial = _get_mfa_serial(profile)
@@ -500,17 +500,14 @@ def configure_accounts_profiles(profile, region, organization_accounts, project_
         if account_id is None:
             continue
 
-        account_profile = {
+        # A profile identifier looks like `le-security-oaar`
+        account_profiles[f"{short_name}-{account_name}-{PROFILES[type]['profile_role']}"] = {
             "output": "json",
             "region": region,
             "role_arn": f"arn:aws:iam::{account_id}:role/{PROFILES[type]['role']}",
-            "source_profile": profile
+            "source_profile": profile,
+            "mfa_serial": mfa_serial
         }
-        if mfa_serial:
-            account_profile["mfa_serial"] = mfa_serial
-
-        # A profile identifier looks like `le-security-oaar`
-        account_profiles[f"{short_name}-{account_name}-{PROFILES[type]['profile_role']}"] = account_profile
 
     logger.info("Backing up account profiles file.")
     _backup_file("config")

--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -15,7 +15,7 @@ from questionary import Choice
 from ruamel.yaml import YAML
 
 from leverage import logger
-from leverage.path import get_home_path
+from leverage.path import get_root_path
 from leverage.path import get_global_config_path
 from leverage.path import NotARepositoryError
 from leverage.modules.terraform import awscli
@@ -41,10 +41,14 @@ MFA_SERIAL = fr"arn:aws:iam::{ACCOUNT_ID}:mfa/{USERNAME}"
 
 # TODO: Remove these and get them into the global app state
 try:
-    AWSCLI_CONFIG_DIR = Path(get_home_path()) / ".aws"
-    PROJECT_COMMON_TFVARS = Path(get_global_config_path()) / "common.tfvars"
+    PROJECT_COMMON_TFVARS = Path(get_global_config_path())
+    PROJECT_ENV = Path(get_root_path())
 except NotARepositoryError:
-    AWSCLI_CONFIG_DIR = PROJECT_COMMON_TFVARS = ""
+    PROJECT_COMMON_TFVARS = PROJECT_ENV = Path.cwd()
+
+PROJECT_COMMON_TFVARS = PROJECT_COMMON_TFVARS / "common.tfvars"
+PROJECT_ENV_CONFIG = PROJECT_ENV / ENV_CONFIG_FILE
+AWSCLI_CONFIG_DIR = Path.home() / ".aws"
 
 PROFILES = {
     "bootstrap": {


### PR DESCRIPTION
## What?
* Updated accounts information obtained by the credential command will no longer be impacted via templates rendering. A more chirurgical approach will be used through the `hcledit` tool.

## Why?
* This will preserve any already configured data instead of re writing the file to a state similar to its original one.
