### PR TITLE
Fix | Make sure image is pulled before formating

### DIFF
--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -304,6 +304,10 @@ def create():
 
     # Format the code correctly
     logger.info("Reformatting terraform configuration to the standard style.")
+    # NOTE: This is done just for the sake of making sure the docker image is already available,
+    # otherwise two animations try to stack on each other and rich does not support that.
+    # TODO: Modularize docker handling as to avoid this.
+    tfrun(command="echo \'pull image\'", enable_mfa=False, interactive=False)
     with console.status("Formatting..."):
         tfrun(command="fmt -recursive", enable_mfa=False, interactive=False)
 

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -307,7 +307,7 @@ def create():
     # NOTE: This is done just for the sake of making sure the docker image is already available,
     # otherwise two animations try to stack on each other and rich does not support that.
     # TODO: Modularize docker handling as to avoid this.
-    tfrun(command="echo \'pull image\'", enable_mfa=False, interactive=False)
+    tfrun(entrypoint="/bin/sh -c", command="'echo \"pull image\"'", enable_mfa=False, interactive=False)
     with console.status("Formatting..."):
         tfrun(command="fmt -recursive", enable_mfa=False, interactive=False)
 


### PR DESCRIPTION
## What?
* Run a random harmless command before running `terraform fmt` just to ensure the docker image is already available.

## Why?
* A status animation is shown during the formatting process. The same happens when the docker image is being pulled. If the image needs to be pulled at the moment of formatting the created project, then the cli attempts to show two status animations at the same time, which is not supported by rich.
