### PR TITLE
Mount host `.ssh` and `.gitconfig` dirs in container

### DIFF
--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -157,8 +157,8 @@ def run(entrypoint=TERRAFORM_BINARY, command="", args=None, enable_mfa=True, int
 
     mounts = [
         Mount(target=WORKING_DIR, source=CWD, type="bind"),
-        # Mount(target="/root/.ssh", source=f"{HOME}/.ssh", type="bind"), # SSH keys for Ansible
-        # Mount(target="/etc/gitconfig", source=f"{HOME}/.gitconfig", type="bind"), # Git user configuration
+        Mount(target="/root/.ssh", source=f"{HOME}/.ssh", type="bind"), # SSH keys for Ansible
+        Mount(target="/etc/gitconfig", source=f"{HOME}/.gitconfig", type="bind"), # Git user configuration
         Mount(target=f"/root/tmp/{project}", source=f"{HOME}/.aws/{project}", type="bind")
     ]
     if Path(str(CONFIG)).exists() and Path(str(ACCOUNT_CONFIG)).exists():


### PR DESCRIPTION
## What?
* Make `.ssh` and `.gitconfig` directories available in the Leverage container.

## References:
 * closes #79
