### PR TITLE
Feature | Mount entire project and load multiple config files

### DIFF
--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -30,7 +30,7 @@ CONTEXT_SETTINGS = {"ignore_unknown_options": True}
 @pass_container
 def init(tf, no_backend, args):
     """ Initialize this layer. """
-    backend_config = ["-backend=false" if no_backend else f"-backend-config={tf.TF_BACKEND_TFVARS}"]
+    backend_config = ["-backend=false" if no_backend else f"-backend-config={tf.backend_tfvars}"]
     args = backend_config + list(args)
     exit_code = tf.start_in_layer("init", *args)
 
@@ -43,7 +43,7 @@ def init(tf, no_backend, args):
 @pass_container
 def plan(tf, args):
     """ Generate an execution plan for this layer. """
-    exit_code = tf.start_in_layer("plan", *tf.TF_DEFAULT_ARGS, *args)
+    exit_code = tf.start_in_layer("plan", *tf.tf_default_args, *args)
 
     if exit_code:
         raise Exit(exit_code)
@@ -54,7 +54,7 @@ def plan(tf, args):
 @pass_container
 def apply(tf, args):
     """ Build or change the infrastructure in this layer. """
-    exit_code = tf.start_in_layer("apply", *tf.TF_DEFAULT_ARGS, *args)
+    exit_code = tf.start_in_layer("apply", *tf.tf_default_args, *args)
 
     if exit_code:
         raise Exit(exit_code)
@@ -73,7 +73,7 @@ def output(tf, args):
 @pass_container
 def destroy(tf, args):
     """ Destroy infrastructure in this layer. """
-    exit_code = tf.start_in_layer("destroy", *tf.TF_DEFAULT_ARGS, *args)
+    exit_code = tf.start_in_layer("destroy", *tf.tf_default_args, *args)
 
     if exit_code:
         raise Exit(exit_code)
@@ -118,7 +118,7 @@ def _format(tf, check):
     """ Check if all files meet the canonical format and rewrite them accordingly. """
     args = ["-recursive"]
     if check:
-        args.extend(["-check", tf.WORKING_DIR])
+        args.extend(["-check", tf.cwd.as_posix()])
 
     tf.disable_authentication()
     tf.start("fmt", *args)
@@ -138,7 +138,7 @@ def validate(tf):
 @pass_container
 def _import(tf, address, _id):
     """ Import a resource. """
-    exit_code = tf.start_in_layer("import", *tf.TF_DEFAULT_ARGS, address, _id)
+    exit_code = tf.start_in_layer("import", *tf.tf_default_args, address, _id)
 
     if exit_code:
         raise Exit(exit_code)


### PR DESCRIPTION
## What?
* Mount whole project instead of only the current layer.
* Load all `.tfvars` files found in global and account config directory when running a terraform command that requires it.

## Why?
* Allows for greater flexibility when working in a project.
* Enables future planned features.

## References
* Closes #90 

