### PR TITLE
Fix | Fix error during project creation

### DIFF
--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -309,7 +309,7 @@ def create():
     terraform.ensure_image()
     terraform.disable_authentication()
     with console.status("Formatting..."):
-        terraform.start("fmt", "-recursive")
+        terraform.exec("fmt", "-recursive")
 
     logger.info("Finished setting up project.")
 


### PR DESCRIPTION
## What?
* Use `exec` instead of `start` when formatting code after creating a project.

## Why?
* `start` launches the container as interactive, which conflicts with the animation displayed by rich when `dockerpty` hijacks the terminal, `exec` runs the operation in the background without interfering with the terminal.

## References
* Addresses point 3 of #92 

