### PR TITLE
Fix | Allow non-conformity upon init

### DIFF
--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -1,5 +1,6 @@
 import re
 from time import sleep
+
 import hcl2
 import click
 from click.exceptions import Exit


### PR DESCRIPTION
## What?
* Some layers' keys add a `-dr` to the layer name, since they are disaster recovery layers, make the layout validation account for that.
* No longer halt initialization when layout validation fails, simply warn the user and give a little time to cancel the operation.