### PR TITLE
114|115 bug accountid not updated, failure on missing project.yaml

### DIFF
--- a/.github/workflows/build-push-test-package.yml
+++ b/.github/workflows/build-push-test-package.yml
@@ -33,10 +33,12 @@ jobs:
             echo "[INFO] Get latest version from TestPypi." && \
             LATEST_VERSION=$(curl -sL "https://test.pypi.org/pypi/leverage/json" | jq -r ".releases | keys | sort | .[-1]") && \
             echo "[INFO] Latest version: $LATEST_VERSION" && \
-            RELEASE_VERSION=$(echo $LATEST_VERSION | awk 'BEGIN{FS="."; OFS="."} {print $1,$2,$3+1}')
+            RELEASE_VERSION="$(echo $LATEST_VERSION | awk 'BEGIN{FS="."; OFS="."} {print $1,$2,$3+1}')rc.1"
 
+          echo "[INFO] Checking Release Version (template 9.9.9-rc9)..."
+          ([ $(echo $RELEASE_VERSION | grep -oP "([0-9]*\.[0-9]*\.[0-9]*\-rc[0-9]+)") ] && echo "[INFO] Version ok" ) || (echo "[ERROR] Version is wrong" && exit 1)
           echo "[INFO] Bump version to $RELEASE_VERSION"
-          sed -i s/$CURRENT_VERSION/$RELEASE_VERSION/ $INIT_FILE
+          sed -i 's/'$CURRENT_VERSION'/'$RELEASE_VERSION'/' $INIT_FILE
         env:
           INIT_FILE: leverage/__init__.py
           RELEASE_VERSION: ${{ github.event.inputs.version }}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ To run all tests, run `make tests`. Alternatively `make test-unit` or `make test
 * The release draft has to be manually published. This allows for any number of PR (features, fixes) to make the cut.
 * Once a release is published, another workflow is triggered to create and push the package to PyPi.
 
+## Release Candidate Process
+* There is an Action called "Test Build Package and Push".
+* This Action can be called manually on any branch specifying the version to release to test.
+    * The version is a Release Candidate following the Semver: e.g. if the next release is 1.2.3, the test version should be 1.2.3-rc.1
+* The package will be published to [Test PyPi](https://test.pypi.org/project/leverage/).
 
 ## Contributors/Contributing
 * Leverage CLI was initially based on Pynt: https://github.com/rags/pynt


### PR DESCRIPTION
## What?
* The `common.tfvars` file update was made to a wrong directory, fixed to the correct one
* Failure when `project.yaml` does not exist; fixed with the logic stated [here](https://github.com/binbashar/leverage/blob/0a78b7d8b0aad5f4d170822940bf79c2e451b072/leverage/modules/credentials.py#L234)

## Why?
* The first item prevented the credentials from being updated in the common.tfvars files, causing the rest of the process to fail
* The second iten prevented the Leverage process from running when `project.yaml` file does not exist

## References
n/a

