### PR TITLE
ISSUE-113 updated toolbox image name and version 

### DIFF
--- a/leverage/container.py
+++ b/leverage/container.py
@@ -49,7 +49,7 @@ class LeverageContainer:
 
     NOTE: An aggregation approach to this design should be considered instead of the current inheritance approach.
     """
-    LEVERAGE_IMAGE = "binbash/terraform-awscli-slim"
+    LEVERAGE_IMAGE = "binbash/leverage-toolbox"
 
     SSO_LOGIN_URL = "https://device.sso.{region}.amazonaws.com"
 

--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -261,7 +261,7 @@ def credentials(state):
             logger.error("Invalid or missing project short name in project.yaml file.")
             raise Exit(1)
         if not build_env.exists():
-            build_env.write_text(f"PROJECT={short_name}\nTERRAFORM_IMAGE_TAG=1.1.9")
+            build_env.write_text(f"PROJECT={short_name}\nTERRAFORM_IMAGE_TAG=1.2.7-latest")
     elif not build_env.exists():
         # project_config is not empty
         # and build.env does not exist


### PR DESCRIPTION
## What?
* toolbox image updated to load the new image at https://github.com/binbashar/le-docker-leverage-toolbox/
* updated the version to load latest for a given terraform version (e.g. 1.7.5-latest)

## Why?
* leveragecli is switching the back container image to a new specific one

## References
* https://github.com/binbashar/le-docker-leverage-toolbox/


