### PR TITLE
HOTFIX sso expiration time calculation fixed

### DIFF
--- a/leverage/container.py
+++ b/leverage/container.py
@@ -471,7 +471,7 @@ class TerraformContainer(LeverageContainer):
         _, cached_token = self._exec(f"sh -c 'cat $SSO_CACHE_DIR/{sso_role}'")
         token = json.loads(cached_token)
         expiry = datetime.strptime(token.get("expiresAt"), "%Y-%m-%dT%H:%M:%SZ")
-        renewal = datetime.now() + timedelta(hours=7)
+        renewal = datetime.utcnow()
 
         if expiry < renewal:
             logger.error("AWS SSO token has expired, please log back in.")


### PR DESCRIPTION
## What?
* Changed the way to determine the expiration validity for an SSO token

## Why?
* As per the related issue it is being calculated wrongly.

## References
* Closes #131 

