### PR TITLE
ISSUE-139 Set specific toolbox version instead of latest

### DIFF
--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -4,7 +4,7 @@
 #pylint: disable=wrong-import-position
 
 __version__ = "0.0.0"
-__toolbox_version__ = "1.2.7-latest"
+__toolbox_version__ = "1.2.7-0.0.5"
 
 import sys
 from shutil import which


### PR DESCRIPTION
## What?
* set specific toolbox version instead of latest

## Why?
* to fix CLI to a specific version of Toolbox (this can be overwritten)

## References
* https://github.com/binbashar/leverage/blob/fbcfeb10cf0b7ee16c343dbcd15a16bd2519d0c5/leverage/__init__.py#L7

