### PR TITLE
ISSUE-146 docuented new build.env format

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: [3.10.8]
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8.15,3.9.15,3.10.8]
+        python-version: [3.8.14,3.9.15,3.10.8]
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,9 +39,17 @@ jobs:
 
   integration_tests_cli_refarch:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.10]
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Build Leverage CLI
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,6 +40,7 @@ jobs:
   integration_tests_cli_refarch:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         python-version: [3.8.14,3.9.15,3.10.8]
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10.8]
+        python-version: [3.8.15,3.9.15,3.10.8]
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v3

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ python_version = ">=3.8"
 pylint = "==2.9.3"
 pytest = "==6.2.4"
 pytest-cov = "==2.12.1"
-setuptools = "==56.2.0"
+setuptools = "==58.2.0"
 wheel = "==0.36.2"
 twine = "==3.4.1"
 leverage = {editable = true, path = "."}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,42 @@ Provides the means to interact with your Leverage project and allows you to defi
 ## Documentation
 For installation instructions and all documentation regarding Leverage CLI, please refer to [this page](https://leverage.binbash.com.ar/how-it-works/leverage-cli/).
 
+### Note for migration from previous versions
+
+If you come from Leverage CLI version <1.8.0 and want to install Leverage CLI version >= 1.8.0 keep into account the following.
+
+The `build.env` file format has changed. As an example, this is the old format:
+```
+# Project settings
+PROJECT=bb
+
+# General
+MFA_ENABLED=false
+
+# Terraform
+TERRAFORM_IMAGE_NAME=binbash/terraform-awscli-slim
+TERRAFORM_IMAGE_TAG=1.1.9
+```
+
+New version example:
+```
+# Project settings
+PROJECT=bb
+
+# General
+MFA_ENABLED=false
+
+# Terraform
+TERRAFORM_IMAGE_TAG=1.2.7-0.0.5
+```
+
+So, if you have created a project with version <1.8.0 and want to use it with version >=1.8.0 you should:
+
+- remove TERRAFORM_IMAGE_NAME line
+- update TERRAFORM_IMAGE_TAG from this form '9.9.9' to this one '9.9.9-9.9.9'. 
+
+For the second item you can check the version [here](https://hub.docker.com/r/binbash/leverage-toolbox/tags).
+
 ## Running Tests
 To run unit tests, pytest is the tool of choice, and the required dependencies are available in the corresponding `dev-requirements.txt`.
 


### PR DESCRIPTION
# What?

The new Leverage CLI version >=1.8.0 uses a new image as background toolbox. Since the versioning for it is other than the old one, and if a project was firstly created with a Leverage CLI <1.8.0, the `build.env` file has to be changed.
Document this change.

How?

Old `build.env` version example:
```
# Project settings
PROJECT=bb

# General
MFA_ENABLED=false

# Terraform
TERRAFORM_IMAGE_NAME=binbash/terraform-awscli-slim
TERRAFORM_IMAGE_TAG=1.1.9
```

New version example:
```
# Project settings
PROJECT=bb

# General
MFA_ENABLED=false

# Terraform
TERRAFORM_IMAGE_TAG=1.2.7-0.0.5
```