### PR TITLE
Issue 141 s3 key multi region support

### DIFF
--- a/.github/workflows/build-push-test-package.yml
+++ b/.github/workflows/build-push-test-package.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
 
       - name: install_dependencies
         run: |

--- a/.github/workflows/build-push-test-package.yml
+++ b/.github/workflows/build-push-test-package.yml
@@ -36,7 +36,7 @@ jobs:
             RELEASE_VERSION="$(echo $LATEST_VERSION | awk 'BEGIN{FS="."; OFS="."} {print $1,$2,$3+1}')rc.1"
 
           echo "[INFO] Checking Release Version (template 9.9.9-rc9)..."
-          ([ $(echo $RELEASE_VERSION | grep -oP "([0-9]*\.[0-9]*\.[0-9]*\-rc[0-9]+)") ] && echo "[INFO] Version ok" ) || (echo "[ERROR] Version is wrong" && exit 1)
+          ([ $(echo $RELEASE_VERSION | grep -oP "([0-9]*\.[0-9]*\.[0-9]*\-(rc|alpha|beta)[0-9]+)") ] && echo "[INFO] Version ok" ) || (echo "[ERROR] Version is wrong" && exit 1)
           echo "[INFO] Bump version to $RELEASE_VERSION"
           sed -i 's/'$CURRENT_VERSION'/'$RELEASE_VERSION'/' $INIT_FILE
         env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,6 @@
 name: Run tests 
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   unit_tests:
@@ -37,26 +37,180 @@ jobs:
           make test-int
         shell: bash
 
-  reference_architecture_tests:
+  integration_tests_cli_refarch:
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: [3.8.14,3.9.15,3.10.8]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout base branch
+        uses: actions/checkout@v3
 
-      - name: Authenticate
-        id: authentication
-        uses: binbashar/github-app-authentication-action@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          appId: ${{ secrets.GHAPP_APP_ID }}
-          clientId: ${{ secrets.GHAPP_CLIENT_ID }}
-          privateKey: ${{ secrets.GHAPP_PRIVATE_KEY }}
-          installationId: ${{ secrets.GHAPP_INSTALLATION_ID }}
-      
-      - name: Run Reference Architecture Tests
-        uses: binbashar/trigger-workflow-and-wait@v1.6.3
-        with:
-          owner: binbashar
-          repo: le-tf-infra-aws
-          ref: master
-          github_token: ${{ steps.authentication.outputs.token }}
-          workflow_file_name: leverage-cli-test.yml
-          client_payload: '{"leverage_branch": "${{ github.ref }}"}'
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build Leverage CLI
+        run: |
+          printf "[INFO] Building Leverage CLI\n"
+          if ! (which pipenv 2>/dev/null); then printf "Installing pipenv..." && pip install pipenv && pipenv --python $(which python) ; else printf "pipenv is already installed"; fi
+          printf "Working with python version $(python --version)"
+          make build
+          pip install -e .
+
+      - name: Create directories
+        run: |
+          mkdir -p ../theadamproject
+          # These are later mounted in the container
+          mkdir ~/.ssh && touch ~/.gitconfig
+
+      - name: Project Init
+        run: |
+          printf "[INFO] Project Init\n"
+          leverage project init
+          if [[ -f project.yaml ]];
+          then
+              printf "[INFO]    OK \n"
+          else
+              printf "[ERROR]    Fail \n"
+              exit 1
+          fi
+        working-directory: ../theadamproject
+
+      - name: Set project file and create
+        run: |
+          printf "[INFO] Setting Project file\n"
+          sed 's/<project name>/The Adam Project/' -i project.yaml
+          sed 's/<short project name>/bb/' -i project.yaml
+          sed 's/<management email address>/bb@domainmgmt/' -i project.yaml
+          sed 's/<security email address>/bb@domainsec/' -i project.yaml
+          sed 's/<shared email address>/bb@domainshared/' -i project.yaml
+          sed 's/<user.name>/bbuser/' -i project.yaml
+          printf "[INFO] Creating Project"
+          leverage project create
+          printf "[INFO] Checking Project"
+          for i in config management security shared; do if [[ ! -d $i ]]; then echo '[ERROR] Fail' && exit 1; fi ;done
+
+        working-directory: ../theadamproject
+
+      - name: Set up credentials
+        run: |
+          printf "[INFO] Setting up credentials\n"
+          mkdir -p  ~/.aws/bb
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} --profile bb-deploymaster
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} --profile bb-deploymaster
+          aws configure set region us-east-1 --profile bb-apps-devstg-devops
+          aws configure set output json --profile bb-apps-devstg-devops
+          aws configure set role_arn arn:aws:iam::${{ secrets.AWS_DEVSTG_ACCOUNT_ID }}:role/DeployMaster --profile bb-apps-devstg-devops
+          aws configure set source_profile bb-deploymaster --profile bb-apps-devstg-devops
+          cat << EOF > ~/.aws/credentials
+          [bb-deploymaster]
+          aws_access_key_id = ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key = ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          EOF
+          cp ~/.aws/credentials ~/.aws/bb/
+          cp ~/.aws/config ~/.aws/bb/
+
+      - name: Configure Reference Architecture
+        run: |
+          echo "[INFO] Configure Reference Architecture\n"
+          cat << EOF > ./config/common.tfvars
+          project = "bb"
+          project_long = "binbash"
+          region_primary = "us-east-1"
+          region_secondary = "us-east-2"
+          vault_address = "vault_trash"
+          vault_token = "vault_trash"
+          sso_region = "us-east-1"
+          sso_enabled = false
+          sso_start_url = "sso_trash"
+
+          accounts = {
+            security = {
+              id = ${{ secrets.AWS_SECURITY_ACCOUNT_ID }}
+            }
+          }
+          EOF
+          echo "[INFO] Disable MFA\n"
+          sed -i "s/^\(MFA_ENABLED=\)true/\1false/" build.env
+        working-directory: ../theadamproject
+
+      - name: Test Terraform
+        run: |
+          printf "[INFO] Testing terraform\n"
+
+          printf "[INFO]     Initializing layer\n"
+          leverage tf init --skip-validation
+
+        working-directory: ../theadamproject/security/us-east-1/base-tf-backend
+
+      - name: Test AWS
+        run: |
+          printf "[INFO] Testing AWS\n"
+
+          printf "[INFO]     Getting identity\n"
+          ID=$(leverage aws sts get-caller-identity --profile bb-apps-devstg-devops | grep Account | sed -E 's/^.*("Account.+")[0-9]{12}".*$/\1************"/')
+          if [[ "$ID" == "\"Account\": \"************\"" ]];
+          then
+              printf "[INFO]    OK \n"
+          else
+              printf "[ERROR]    Fail \n"
+              exit 1
+          fi
+
+        working-directory: ../theadamproject/security/us-east-1/base-tf-backend
+
+
+      - name: Clone Testing Reference Architecture repo
+        run: |
+          printf "[INFO] Cloning repo...\n"
+          git clone https://github.com/binbashar/le-tf-infra-aws.git ../theblairwitchproject
+
+      - name: Configure Testing Reference Architecture
+        run: |
+          echo "[INFO] Configure Reference Architecture\n"
+          cat << EOF > ./config/common.tfvars
+          project = "bb"
+          project_long = "binbash"
+          region_primary = "us-east-1"
+          region_secondary = "us-east-2"
+          vault_address = "vault_trash"
+          vault_token = "vault_trash"
+          sso_region = "us-east-1"
+          sso_enabled = false
+          sso_start_url = "sso_trash"
+
+          accounts = {
+            security = {
+              id = ${{ secrets.AWS_SECURITY_ACCOUNT_ID }}
+            }
+          }
+          EOF
+          echo "[INFO] Disable MFA\n"
+          sed -i "s/^\(MFA_ENABLED=\)true/\1false/" build.env
+          sed -E -i 's/^TERRAFORM_IMAGE_TAG=.+$/TERRAFORM_IMAGE_TAG=1.2.7-latest/' build.env;
+        working-directory: ../theblairwitchproject
+
+      - name: Test Testing Reference Architecture
+        run: |
+
+          printf "[INFO] Initializing layer\n"
+          leverage tf init
+
+          printf "[INFO] Generating plan\n"
+          leverage tf plan
+
+          printf "[INFO] Applying changes\n"
+          leverage tf apply -auto-approve
+
+          printf "[INFO] Checking if all changes were applied\n"
+          leverage tf plan -detailed-exitcode
+          [[ $? -eq 2 ]] && printf "[WARN] There are still remaining changes\n"
+          [[ $? -eq 0 ]] && printf "[INFO] Apply checks out\n"
+
+          printf "[INFO] Destroying all generated created resources\n"
+          leverage tf destroy -auto-approve
+        working-directory: ../theblairwitchproject/apps-devstg/global/cli-test-layer
+

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -190,7 +190,7 @@ jobs:
           EOF
           echo "[INFO] Disable MFA\n"
           sed -i "s/^\(MFA_ENABLED=\)true/\1false/" build.env
-          sed -E -i 's/^TERRAFORM_IMAGE_TAG=.+$/TERRAFORM_IMAGE_TAG=1.2.7-latest/' build.env;
+          sed -E -i 's/^TERRAFORM_IMAGE_TAG=.+$/TERRAFORM_IMAGE_TAG=1.2.7-0.0.5/' build.env;
         working-directory: ../theblairwitchproject
 
       - name: Test Testing Reference Architecture

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help build
 LEVERAGE_TESTING_IMAGE := binbash/leverage-cli-testing
 LEVERAGE_TESTING_TAG   := 2.5.0
-LEVERAGE_IMAGE_TAG     := 1.2.7-latest
+LEVERAGE_IMAGE_TAG     := 1.2.7-0.0.5
 
 help:
 	@echo 'Available Commands:'

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ PROJECT=bb
 MFA_ENABLED=false
 
 # Terraform
-TERRAFORM_IMAGE_TAG=1.2.7-0.0.5
+TERRAFORM_IMAGE_TAG=1.2.7-0.1.0
 ```
 
 So, if you have created a project with version <1.8.0 and want to use it with version >=1.8.0 you should:

--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -4,7 +4,7 @@
 #pylint: disable=wrong-import-position
 
 __version__ = "0.0.0"
-__toolbox_version__ = "1.2.7-0.0.5"
+__toolbox_version__ = "1.2.7-0.1.0"
 
 import sys
 from shutil import which

--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -4,7 +4,7 @@
 #pylint: disable=wrong-import-position
 
 __version__ = "0.0.0"
-__toolbox_version__ = "1.3.5-latest"
+__toolbox_version__ = "1.2.7-0.0.5"
 
 import sys
 from shutil import which

--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -4,7 +4,7 @@
 #pylint: disable=wrong-import-position
 
 __version__ = "0.0.0"
-__toolbox_version__ = "1.2.7-latest"
+__toolbox_version__ = "1.3.5-latest"
 
 import sys
 from shutil import which

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -569,7 +569,7 @@ class TerraformContainer(LeverageContainer):
                 region = self._find_region(Path(directory).relative_to(self.account_dir))
 
                 if not region is None:
-                    return { 'directory': directory , 'region': region}
+                    return {'directory': directory , 'region': region}
                 else:
                     logger.error("No region found for backend layer")
                     raise Exit(1)

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -587,6 +587,10 @@ class TerraformContainer(LeverageContainer):
             return self.account_conf.get('region')
         if 'region' in self.common_conf:
             return self.common_conf.get('region')
+        if 'region_primary' in self.account_conf:
+            return self.account_conf.get('region_primary')
+        if 'region_primary' in self.common_conf:
+            return self.common_conf.get('region_primary')
 
         return None
 

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -605,6 +605,7 @@ class TerraformContainer(LeverageContainer):
     def backend_key(self, backend_key):
         self._backend_key = backend_key
 
+
 class TFautomvContainer(TerraformContainer):
     """ Leverage Container tailored to run general commands. """
     TFAUTOMV_CLI_BINARY = '/usr/local/bin/tfautomv'

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -438,7 +438,7 @@ class TerraformContainer(LeverageContainer):
         account_config_files = [f"-var-file={self._guest_config_file(account_file)}"
                                 for account_file in self.account_config_dir.glob("*.tfvars")]
         region_settings      = [f"-var=\"region={self.region}\""]
-        return common_config_files + account_config_files
+        return common_config_files + account_config_files + region_settings
 
     def enable_mfa(self):
         """ Enable Multi-Factor Authentication. """

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -635,3 +635,4 @@ class TFautomvContainer(TerraformContainer):
         self._prepare_container()
 
         return self._exec(command, *arguments)
+

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -13,6 +13,7 @@ from leverage.modules import run
 from leverage.modules import project
 from leverage.modules import terraform
 from leverage.modules import credentials
+from leverage.modules import tfautomv
 
 @click.group(invoke_without_command=True)
 @click.option("--filename", "-f",
@@ -53,3 +54,4 @@ leverage.add_command(terraform)
 leverage.add_command(terraform, name="tf")
 leverage.add_command(credentials)
 leverage.add_command(aws)
+leverage.add_command(tfautomv)

--- a/leverage/modules/__init__.py
+++ b/leverage/modules/__init__.py
@@ -3,3 +3,4 @@ from .run import run
 from .project import project
 from .terraform import terraform
 from .credentials import credentials
+from .tfautomv import tfautomv

--- a/leverage/modules/aws.py
+++ b/leverage/modules/aws.py
@@ -174,10 +174,13 @@ def sso(context, cli, args):
 @pass_container
 def login(cli):
     """ Login """
-    if (cli.cwd in (cli.root_dir, cli.account_dir) or
-        cli.account_dir.parent != cli.root_dir or
-        not list(cli.cwd.glob("*.tf"))):
-        logger.error("SSO configuration can only be performed at [bold]layer[/bold] level.")
+    # only from account or layer directories
+    # when to fail:
+    # - when this cond meets:
+    #   - no account dir
+    #   - no layer dir
+    if not cli.get_location_type() in ['account', 'layer', 'layers-group']:
+        logger.error("SSO configuration can only be performed at [bold]layer[/bold] or [bold]account[/bold] level.")
         raise Exit(1)
 
     exit_code, region = cli.exec(f"configure get sso_region --profile {cli.project}-sso")

--- a/leverage/modules/aws.py
+++ b/leverage/modules/aws.py
@@ -87,7 +87,12 @@ def _sso(context, cli):
         logger.error("SSO configuration can only be performed at [bold]layer[/bold] level.")
         raise Exit(1)
 
-    default_region = cli.common_conf.get("region_primary", cli.common_conf.get("sso_region"))
+    # region_primary was added in refarch v1
+    # for v2 it was replaced by region at project level
+    region_primary = 'region_primary'
+    if not 'region_primary' in cli.common_conf:
+        region_primary = 'region'
+    default_region = cli.common_conf.get(region_primary, cli.common_conf.get("sso_region"))
     if default_region is None:
         logger.error("No primary region configured in global config file.")
         raise Exit(1)
@@ -111,10 +116,27 @@ def _sso(context, cli):
 
     current_account = cli.account_conf.get("environment")
     try:
+        # this is for refarch v1
         account_id = cli.common_conf.get("accounts").get(current_account).get("id")
     except AttributeError:
-        logger.error("Missing environment configuration in global config file.")
-        raise Exit(1)
+        # this is for refarch v2
+        try:
+            # this is for accounts with no org unit on top of it
+            account_id = cli.common_conf.get("organization").get("accounts").get(current_account).get("id")
+        except AttributeError:
+            try:
+                # this is for accounts with no org unit on top of it
+                found = False
+                for ou in cli.common_conf.get("organization").get("organizational_units"):
+                    if current_account in cli.common_conf.get("organization").get("organizational_units").get(ou).get("accounts"):
+                        account_id = cli.common_conf.get("organization").get("organizational_units").get(ou).get("accounts").get(current_account).get("id")
+                        found = True
+                        break
+                if not found:
+                    raise AttributeError
+            except AttributeError:
+                logger.error(f"Missing account configuration for [bold]{current_account}[/bold] in global config file.")
+                raise Exit(1)
     if not account_id:
         logger.error(f"Missing id for account [bold]{current_account}[/bold].")
         raise Exit(1)
@@ -122,7 +144,7 @@ def _sso(context, cli):
     logger.info(f"Configuring [bold]{cli.project}-sso[/bold] profile.")
     sso_profile = {
         "sso_start_url": cli.common_conf.get("sso_start_url"),
-        "sso_region": cli.common_conf.get("sso_region", cli.common_conf.get("region_primary")),
+        "sso_region": cli.common_conf.get("sso_region", cli.common_conf.get(region_primary)),
         "sso_account_id": account_id,
         "sso_role_name": sso_role
     }

--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -324,7 +324,7 @@ def _load_configs_for_credentials():
     region_primary = 'region_primary'
     if not 'region_primary' in project_config and not 'region_primary' in terraform_config:
         region_primary = 'region'
-    config_values["primary_region"] = (project_config.get(primary_region)
+    config_values["primary_region"] = (project_config.get(region_primary)
                                            or terraform_config.get(region_primary)
                                            or _ask_for_region())
     config_values["secondary_region"] = terraform_config.get("region_secondary")

--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -319,8 +319,13 @@ def _load_configs_for_credentials():
     config_values["project_name"] = (project_config.get("project_name")
                                          or terraform_config.get("project_long"))
 
-    config_values["primary_region"] = (project_config.get("primary_region")
-                                           or terraform_config.get("region_primary")
+    # region_primary was added in refarch v1
+    # for v2 it was replaced by region at project level
+    region_primary = 'region_primary'
+    if not 'region_primary' in project_config and not 'region_primary' in terraform_config:
+        region_primary = 'region'
+    config_values["primary_region"] = (project_config.get(primary_region)
+                                           or terraform_config.get(region_primary)
                                            or _ask_for_region())
     config_values["secondary_region"] = terraform_config.get("region_secondary")
 

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -177,7 +177,7 @@ def _make_layer_backend_key(cwd, account_dir, account_name):
         for lp in layer_path:
             if lp.startswith('base-'):
                 lp = lp.replace('base-','')
-            elif lp.startswith('tools'):
+            elif lp.startswith('tools-'):
                 lp = lp.replace('tools-','')
             curated_layer_path.append(lp)
         curated_layer_paths.append(curated_layer_path)

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -1,4 +1,6 @@
 import re
+import os
+from pathlib import Path
 
 import hcl2
 import click
@@ -13,6 +15,9 @@ from leverage.container import TerraformContainer
 REGION = (r"global|(?:[a-z]{2}-(?:gov-)?"
           r"(?:central|north|south|east|west|northeast|northwest|southeast|southwest|secret|topsecret)-[1-4])")
 
+# ###########################################################################
+# CREATE THE TERRAFORM GROUP
+# ###########################################################################
 @click.group()
 @pass_state
 def terraform(state):
@@ -30,76 +35,83 @@ CONTEXT_SETTINGS = {
     "ignore_unknown_options": True
 }
 
+# ###########################################################################
+# CREATE THE TERRAFORM GROUP'S COMMANDS
+# ###########################################################################
+#
+# --layers is a ordered comma separated list of layer names
+# The layer names are the relative paths of those layers relative to the current directory
+# e.g. if CLI is called from /home/user/project/management and this is the tree:
+# home
+# ├── user
+# │   └── project
+# │       └── management
+# │           ├── global
+# │           |   └── security-base
+# │           |   └── sso
+# │           └── us-east-1
+# │               └── terraform-backend
+#
+# Then all three layers can be initialized as follows:
+# leverage tf init --layers us-east-1/terraform-backend,global/security-base,global/sso
+#
+# It is an ordered list because the layers will be visited in the same order they were
+# supplied.
+#
+layers_option = click.option("--layers",
+                             type=str,
+                             default="",
+                             help="Layers to apply the action to. (an ordered, comma-separated list of layer names)")
+
 @terraform.command(context_settings=CONTEXT_SETTINGS)
 @click.option("--skip-validation",
               is_flag=True,
               help="Skip layout validation.")
+@layers_option
 @click.argument("args", nargs=-1)
 @pass_container
 @click.pass_context
-def init(context, tf, skip_validation, args):
-    """ Initialize this layer. """
-    # Validate layout before attempting to initialize Terraform
-    if not skip_validation and not context.invoke(validate_layout):
-        logger.error("Layer configuration doesn't seem to be valid. Exiting.\n"
-                     "If you are sure your configuration is actually correct "
-                     "you may skip this validation using the --skip-validation flag.")
-        raise Exit(1)
-
-    args = [arg for index, arg in enumerate(args)
-            if not arg.startswith("-backend-config") or not arg[index - 1] == "-backend-config"]
-    args.append(f"-backend-config={tf.backend_tfvars}")
-    args.append(f"-backend-config=\"region={tf.terraform_backend.get('region')}\"")
-    # if the backend key is set send it as a backend config
-    if not tf.backend_key is None:
-        args.append(f"-backend-config=\"key={tf.backend_key}\"")
-
-    exit_code = tf.start_in_layer("init", *args)
-
-    if exit_code:
-        raise Exit(exit_code)
-
+def init(context, tf, skip_validation, layers, args):
+    """
+    Initialize this layer.
+    """
+    invoke_for_all_commands(layers, _init, args, skip_validation)
 
 @terraform.command(context_settings=CONTEXT_SETTINGS)
+@layers_option
 @click.argument("args", nargs=-1)
 @pass_container
-def plan(tf, args):
+@click.pass_context
+def plan(context, tf, layers, args):
     """ Generate an execution plan for this layer. """
-    exit_code = tf.start_in_layer("plan", *tf.tf_default_args, *args)
-
-    if exit_code:
-        raise Exit(exit_code)
-
+    invoke_for_all_commands(layers, _plan, args)
 
 @terraform.command(context_settings=CONTEXT_SETTINGS)
+@layers_option
 @click.argument("args", nargs=-1)
 @pass_container
-def apply(tf, args):
+@click.pass_context
+def apply(context, tf, layers, args):
     """ Build or change the infrastructure in this layer. """
-    exit_code = tf.start_in_layer("apply", *tf.tf_default_args, *args)
-
-    if exit_code:
-        raise Exit(exit_code)
-
+    invoke_for_all_commands(layers, _apply, args)
 
 @terraform.command(context_settings=CONTEXT_SETTINGS)
+@layers_option
 @click.argument("args", nargs=-1)
 @pass_container
-def output(tf, args):
+@click.pass_context
+def output(context, tf, layers, args):
     """ Show all output variables of this layer. """
-    tf.start_in_layer("output", *args)
-
+    invoke_for_all_commands(layers, _output, args)
 
 @terraform.command(context_settings=CONTEXT_SETTINGS)
+@layers_option
 @click.argument("args", nargs=-1)
 @pass_container
-def destroy(tf, args):
+@click.pass_context
+def destroy(context, tf, layers, args):
     """ Destroy infrastructure in this layer. """
-    exit_code = tf.start_in_layer("destroy", *tf.tf_default_args, *args)
-
-    if exit_code:
-        raise Exit(exit_code)
-
+    invoke_for_all_commands(layers, _destroy, args)
 
 @terraform.command()
 @pass_container
@@ -107,7 +119,6 @@ def version(tf):
     """ Print version. """
     tf.disable_authentication()
     tf.start("version")
-
 
 @terraform.command()
 @click.option("--mfa",
@@ -130,7 +141,6 @@ def shell(tf, mfa, sso):
 
     tf.start_shell()
 
-
 @terraform.command("format", context_settings=CONTEXT_SETTINGS)
 @click.argument("args", nargs=-1)
 @pass_container
@@ -140,7 +150,6 @@ def _format(tf, args):
     tf.disable_authentication()
     tf.start("fmt", *args)
 
-
 @terraform.command()
 @pass_container
 def validate(tf):
@@ -148,7 +157,185 @@ def validate(tf):
     tf.disable_authentication()
     tf.start("validate")
 
+@terraform.command("validate-layout")
+@pass_container
+def validate_layout(tf):
+    """ Validate layer conforms to Leverage convention. """
+    tf.set_backend_key()
+    return _validate_layout()
 
+@terraform.command("import")
+@click.argument("address")
+@click.argument("_id", metavar="ID")
+@pass_container
+def _import(tf, address, _id):
+    """ Import a resource. """
+    exit_code = tf.start_in_layer("import", *tf.tf_default_args, address, _id)
+
+    if exit_code:
+        raise Exit(exit_code)
+
+# ###########################################################################
+# HANDLER FOR MANAGING THE BASE COMMANDS (init, plan, apply, destroy, output)
+# ###########################################################################
+@pass_container
+def invoke_for_all_commands(tf, layers, command, args, skip_validation=True):
+    """
+    Invoke helper for "all" commands.
+
+    Args:
+        layers: comma separated value of relative layer path
+            e.g.: global/security_audit,us-east-1/tf-backend
+        command: init, plan, apply
+    """
+
+    # convert layers from string to list
+    layers = layers.split(',') if len(layers) > 0 else []
+
+    # based on the location type manage the layers parameter
+    if tf.get_location_type() == 'layer' and len(layers) == 0:
+        # running on a layer
+        layers = [tf.cwd]
+    elif tf.get_location_type() == 'layer':
+        # running on a layer but --layers was set
+        logger.error("Can not set [bold]--layers[/bold] inside a layer.")
+        raise Exit(1)
+    elif tf.get_location_type() in ['account','layers-group'] and len(layers) == 0:
+        # running on an account but --layers was not set
+        logger.error("[bold]--layers[/bold] has to be set.")
+        raise Exit(1)
+    elif not tf.get_location_type() in ['account', 'layer', 'layers-group']:
+        # running outside a layer and account
+        logger.error('This command has to be run inside a layer or account directory.')
+        raise Exit(1)
+    else:
+        # running on an account with --layers set
+        layers = [ tf.cwd / x for x in layers]
+
+    # get current location
+    original_location = tf.cwd
+    original_working_dir = tf.container_config['working_dir']
+
+    # validate each layer before calling the execute command
+    for layer in layers:
+        logger.debug(f"Checking for layer {layer}...")
+        # change to current dir and set it in the container
+        tf.cwd = layer
+
+        # set the s3 key
+        tf.set_backend_key(skip_validation)
+
+        #validate layer
+        validate_for_all_commands(layer, skip_validation=skip_validation)
+
+        # change to original dir and set it in the container
+        tf.cwd = original_location
+
+    # check layers existence
+    for layer in layers:
+        if len(layers) > 1:
+            logger.info(f"Invoking command for layer {layer}...")
+
+        # change to current dir and set it in the container
+        tf.cwd = layer
+
+        # set the working dir
+        tf.container_config['working_dir'] = f"{tf.guest_base_path}/{tf.cwd.relative_to(tf.root_dir).as_posix()}"
+
+        # execute the actual command
+        command(args=args)
+
+        # change to original dir and set it in the container
+        tf.cwd = original_location
+
+        # change to original workgindir
+        tf.container_config['working_dir'] = original_working_dir
+
+def validate_for_all_commands(layer, skip_validation=False):
+    """
+    Validate existense of layer and, if set, all the Leverage related stuff
+    of each of them
+
+    Args:
+        layer: a full layer directory
+    """
+
+    # check layers existence
+    logger.debug(f"Checking layer {layer}...")
+    if not layer.is_dir():
+        logger.error(f"Directory [red]{layer}[/red] does not exist or is not a directory\n")
+        raise Exit(1)
+
+    if not skip_validation and not _validate_layout():
+        logger.error("Layer configuration doesn't seem to be valid. Exiting.\n"
+                    "If you are sure your configuration is actually correct "
+                    "you may skip this validation using the --skip-validation flag.")
+        raise Exit(1)
+
+# ###########################################################################
+# BASE COMMAND EXECUTORS
+# ###########################################################################
+@pass_container
+def _init(tf, args):
+    """ Initialize this layer. """
+
+    args = [arg for index, arg in enumerate(args)
+            if not arg.startswith("-backend-config") or not arg[index - 1] == "-backend-config"]
+    args.append(f"-backend-config={tf.backend_tfvars}")
+    args.append(f"-backend-config=\"region={tf.terraform_backend.get('region')}\"")
+    # if the backend key is set send it as a backend config
+    if not tf.backend_key is None:
+        args.append(f"-backend-config=\"key={tf.backend_key}\"")
+
+    exit_code = tf.start_in_layer("init", *args)
+
+    if exit_code:
+        raise Exit(exit_code)
+
+
+@pass_container
+def _plan(tf, args):
+    """ Generate an execution plan for this layer. """
+    exit_code = tf.start_in_layer("plan", *tf.tf_default_args, *args)
+
+    if exit_code:
+        raise Exit(exit_code)
+
+
+@pass_container
+def _apply(tf, args):
+    """ Build or change the infrastructure in this layer. """
+    # if there is a plan, remove all "-var" from the default args
+    tf_default_args  = tf.tf_default_args
+    for arg in args:
+        if not arg.startswith("-"):
+            tf_default_args = [arg for index, arg in enumerate(tf_default_args)
+                    if not arg.startswith("-var")]
+            break
+    exit_code = tf.start_in_layer("apply", *tf_default_args, *args)
+
+    if exit_code:
+        raise Exit(exit_code)
+
+
+@pass_container
+def _output(tf, args):
+    """ Show all output variables of this layer. """
+    tf.start_in_layer("output", *args)
+
+
+@pass_container
+def _destroy(tf, args):
+    """ Destroy infrastructure in this layer. """
+    exit_code = tf.start_in_layer("destroy", *tf.tf_default_args, *args)
+
+    if exit_code:
+        raise Exit(exit_code)
+
+
+# ###########################################################################
+# MISC FUNCTIONS
+# ###########################################################################
 def _make_layer_backend_key(cwd, account_dir, account_name):
     """ Create expected backend key.
 
@@ -218,10 +405,8 @@ def _make_layer_backend_key(cwd, account_dir, account_name):
     return resp
 
 
-@terraform.command("validate-layout")
 @pass_container
-def validate_layout(tf):
-    """ Validate layer conforms to Leverage convention. """
+def _validate_layout(tf):
     tf.check_for_layer_location()
 
     # Check for `environment = <account name>` in account.tfvars
@@ -237,24 +422,7 @@ def validate_layout(tf):
         logger.warning("[yellow]‼[/yellow] Account directory name does not match environment name.\n"
                        f"  Expected [bold]{account_name}[/bold], found [bold]{tf.account_dir.stem}[/bold]\n")
 
-    config_tf = tf.cwd / "config.tf"
-    try:
-        config_tf = hcl2.loads(config_tf.read_text()) if config_tf.exists() else {}
-        if 'terraform' in config_tf and 'backend' in config_tf["terraform"][0] and 's3' in config_tf["terraform"][0]["backend"][0]:
-            if 'key' in config_tf["terraform"][0]["backend"][0]["s3"]:
-                backend_key = config_tf["terraform"][0]["backend"][0]["s3"]["key"]
-                tf.backend_key = backend_key
-            else:
-                backend_key = tf.backend_key
-            backend_key = backend_key.split("/")
-        else:
-            raise KeyError()
-    except (KeyError, IndexError):
-        logger.error("[red]✘[/red] Malformed [bold]config.tf[/bold] file. Missing Terraform backend bucket key.")
-        raise Exit(1)
-    except:
-        logger.error("[red]✘[/red] Malformed [bold]config.tf[/bold] file. Unable to parse.")
-        raise Exit(1)
+    backend_key = tf.backend_key.split('/')
 
     # Flag to report layout validity
     valid_layout = True
@@ -291,14 +459,3 @@ def validate_layout(tf):
 
     return valid_layout
 
-
-@terraform.command("import")
-@click.argument("address")
-@click.argument("_id", metavar="ID")
-@pass_container
-def _import(tf, address, _id):
-    """ Import a resource. """
-    exit_code = tf.start_in_layer("import", *tf.tf_default_args, address, _id)
-
-    if exit_code:
-        raise Exit(exit_code)

--- a/leverage/modules/tfautomv.py
+++ b/leverage/modules/tfautomv.py
@@ -1,0 +1,41 @@
+import re
+
+import hcl2
+import click
+from click.exceptions import Exit
+
+from leverage import logger
+from leverage._internals import pass_state
+from leverage._internals import pass_container
+from leverage.container import get_docker_client
+from leverage.container import TFautomvContainer
+
+REGION = (r"global|(?:[a-z]{2}-(?:gov-)?"
+          r"(?:central|north|south|east|west|northeast|northwest|southeast|southwest|secret|topsecret)-[1-4])")
+
+@click.group()
+@pass_state
+def tfautomv(state):
+    """ Run TFAutomv commands in a custom containerized environment that provides extra functionality when interacting
+    with your cloud provider such as handling multi factor authentication for you.
+    All terraform subcommands that receive extra args will pass the given strings as is to their corresponding Terraform
+    counterparts in the container. For example as in `leverage terraform apply -auto-approve` or
+    `leverage terraform init -reconfigure`
+    """
+    state.container = TFautomvContainer(get_docker_client())
+    state.container.ensure_image()
+
+CONTEXT_SETTINGS = {
+    "ignore_unknown_options": True
+}
+
+@tfautomv.command(context_settings=CONTEXT_SETTINGS)
+@click.argument("args", nargs=-1)
+@pass_container
+def run(tf, args):
+    """ Generate a move tf file for this layer. """
+    exit_code = tf.start_in_layer(*args)
+
+    if exit_code:
+        raise Exit(exit_code)
+


### PR DESCRIPTION
## What?
* S3 keys
  * accept keys with region
  * generate key when the key line in the tf file is missing (the s3 backend line has to be there anyway)
  * accept more versions of the key to match refarch v1 and v2
* test-build workflow allows alpha and beta besides rc
*  toolbox version fixed to `__toolbox_version__ = "1.2.7-0.0.5"`
* added `region` var to the TF command line in TF container
* added logic to handle token file called `token`
* added properties to TF container class
* added TFAutomv container class
* added tfautomv command to Leverage CLI
* aws
  * manage v1 and v2 main region (aka `region_primary` and `region`)
  * added code for accounts and Org Units handle in Refarch v1 and v2
* credentials
  * manage v1 and v2 main region (aka `region_primary` and `region`)
* terraform
  * init: pass backend region dynamically
  * improved `_make_layer_backend_key` for covering refarch v1 and v2
  * improved `validate-layout` for using all the possibilities emanated from the previous item
* Apply TF command to multiple Layers feature added  

## Why?
* we reflect a set of issues here

## References
n/a

## Before release

Review the checklist [here](https://binbash.atlassian.net/wiki/spaces/BDPS/pages/edit-v2/2158034946)