### PR TITLE
ISSUE-153 added Dod-CCP reference to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@
 
 ## Before release
 
-Review the checklist [here](https://binbash.atlassian.net/wiki/spaces/BDPS/pages/edit-v2/2158034946)
+Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,6 @@
 * Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
 * Use `closes #123`, if this PR closes a GitHub issue `#123`
 
+## Before release
+
+Review the checklist [here](https://binbash.atlassian.net/wiki/spaces/BDPS/pages/edit-v2/2158034946)


### PR DESCRIPTION
## What?
* adding Dod-CCP reference to PR template

## Why?
* In order to have a checklist of tasks to be done before every release

## References
n/a

