### PR TITLE
Doc | Adding CODE-OF-CONDUNCT.md and CONTRIBUTING.md

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,8 @@
+# binbash Leverage Community Code of Conduct
+
+Binbash follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
+the Binbash Code of Conduct responsibles via:
+- <leverage@binbash.com.ar>
+- <info@binbash.com.ar>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue
+with the owners of this repository before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment
+   variables, exposed ports, useful file locations and container parameters.
+3. Increase the version numbers in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
+   do not have permission to do that, you may request the second reviewer to merge it for you.
+
+
+### Collaborate on fixes for security vulnerabilities in private forks
+
+Working in the open means that it is impossible to hide things. And yet, sometimes you will want
+to work on some changes in the code in private, for example when fixing a security vulnerability.
+
+Working on a fix in the open might allow attackers to reverse engineer the bug and attack our users.
+Since GitHub provides a mechanism to easily create a private fork of our repo, please use this
+private forks to collaborate on a security fix.
+
+### Publish maintainer advisories for security fixes
+
+Fixing a security vulnerability is no small feat and we should tell our users about it.
+We will do it in a way that will make it easy for you to learn about it and patch
+
+Since GitHub provides an easy way to publish a security advisory, this will
+be incorporated and you could add it into your security scanning tools, the ones you
+depend on to keep your applications secure.
+
+## Read More
+
+[Leverage Open Source Modules management](https://leverage.binbash.com.ar/how-it-works/infra-as-code-library/infra-as-code-library-forks/)


### PR DESCRIPTION
## What?

### Commits on Feb 10, 2023
- [Adding 1st version of the binbash Leverage standard CODE-OF-CONDUNCT.md and CONTRIBUTING.md](https://github.com/binbashar/leverage/commit/196399186ebd583ba05297b18e4cba3eaf9586b7)  - @[exequielrafaela](https://github.com/binbashar/leverage/commits?author=exequielrafaela)

### Why?

Necessary and in line to the following issues:
- https://github.com/binbashar/le-ref-architecture-doc/issues/150
- https://github.com/binbashar/le-ref-architecture-doc/issues/143