### PR TITLE
ISSUE-173 Changed way to add .ssh dir to get rid of bad owner permissions

### DIFF
--- a/leverage/container.py
+++ b/leverage/container.py
@@ -422,7 +422,7 @@ class TerraformContainer(LeverageContainer):
             "SSO_CACHE_DIR": f"{self.guest_aws_credentials_dir}/sso/cache",
             "SCRIPT_LOG_LEVEL": get_script_log_level(),
             "MFA_SCRIPT_LOG_LEVEL": get_script_log_level(), # Legacy
-            "SSH_AUTH_SOCK": '/ssh-agent' if not SSH_AUTH_SOCK is None else ""
+            "SSH_AUTH_SOCK": '' if SSH_AUTH_SOCK is None else '/ssh-agent'
         }
         self.entrypoint = self.TF_BINARY
         self.mounts = [

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -460,8 +460,9 @@ class TerraformContainer(LeverageContainer):
                                for common_file in self.common_config_dir.glob("*.tfvars")]
         account_config_files = [f"-var-file={self._guest_config_file(account_file)}"
                                 for account_file in self.account_config_dir.glob("*.tfvars")]
-        region_settings      = [f"-var=\"region={self.region}\""]
-        return common_config_files + account_config_files + region_settings
+        #region_settings      = [f"-var=\"region={self.region}\""]
+        #return common_config_files + account_config_files + region_settings
+        return common_config_files + account_config_files
 
     def enable_mfa(self):
         """ Enable Multi-Factor Authentication. """

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -391,6 +391,7 @@ class TerraformContainer(LeverageContainer):
     """ Leverage container specifically tailored to run Terraform commands.
     It handles authentication and some checks regarding where the command is being executed. """
     TF_BINARY = "/bin/terraform"
+    TF_ENTRYPOINT = "/root/scripts/terraform/entrypoint.sh"
 
     TF_MFA_ENTRYPOINT = "/root/scripts/aws-mfa/aws-mfa-entrypoint.sh"
     TF_SSO_ENTRYPOINT = "/root/scripts/aws-sso/aws-sso-entrypoint.sh"
@@ -423,7 +424,7 @@ class TerraformContainer(LeverageContainer):
         self.mounts = [
             Mount(source=self.root_dir.as_posix(), target=self.guest_base_path, type="bind"),
             Mount(source=self.host_aws_credentials_dir.as_posix(), target=self.guest_aws_credentials_dir, type="bind"),
-            Mount(source=(self.home / ".ssh").as_posix(), target="/root/.ssh", type="bind"),
+            Mount(source=(self.home / ".ssh").as_posix(), target="/tmp/.ssh", type="bind"),
             Mount(source=(self.home / ".gitconfig").as_posix(), target="/etc/gitconfig", type="bind")
         ]
 
@@ -526,6 +527,9 @@ class TerraformContainer(LeverageContainer):
                 "AWS_SHARED_CREDENTIALS_FILE": self.environment.get("AWS_SHARED_CREDENTIALS_FILE").replace("tmp", ".aws"),
                 "AWS_CONFIG_FILE": self.environment.get("AWS_CONFIG_FILE").replace("tmp", ".aws"),
             })
+        else:
+            self.entrypoint = f"{self.TF_ENTRYPOINT} -- {self.entrypoint}"
+
 
         logger.debug(f"[bold cyan]Running with entrypoint:[/bold cyan] {self.entrypoint}")
 

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -460,8 +460,6 @@ class TerraformContainer(LeverageContainer):
                                for common_file in self.common_config_dir.glob("*.tfvars")]
         account_config_files = [f"-var-file={self._guest_config_file(account_file)}"
                                 for account_file in self.account_config_dir.glob("*.tfvars")]
-        #region_settings      = [f"-var=\"region={self.region}\""]
-        #return common_config_files + account_config_files + region_settings
         return common_config_files + account_config_files
 
     def enable_mfa(self):

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -586,53 +586,6 @@ class TerraformContainer(LeverageContainer):
         self._prepare_container()
         self._start()
 
-    #@property
-    #def region(self):
-    #    """ Determine the region based on PATH, account tfvars or project tfvars. Returns a string with the region name. """
-    #    region = self._find_region(self.cwd.relative_to(self.account_dir))
-
-    #    if not region is None:
-    #        return region
-
-    #    logger.error("No region found")
-    #    raise Exit(1)
-
-    #@property
-    #def terraform_backend(self):
-    #    """ Determine the terraform backend for the account. Returns an object with backend information. """
-    #    # These are the possible backend layer names for Refarch v1 and v2
-    #    possible_layer_names = ['terraform-backend', 'base-tf-backend']
-    #    for layer_name in possible_layer_names:
-    #        for directory in Path(self.account_dir).glob(f"**/{layer_name}"):
-
-    #            region = self._find_region(Path(directory).relative_to(self.account_dir))
-
-    #            if not region is None:
-    #                return {'directory': directory , 'region': region}
-    #            else:
-    #                logger.error("No region found for backend layer")
-    #                raise Exit(1)
-
-    #    logger.error("No backend layer found")
-    #    raise Exit(1)
-
-    #def _find_region(self, local_directory):
-    #    local_directory = local_directory.as_posix().split('/')
-    #    if len(local_directory) > 1:
-    #        if local_directory[0] != 'global':
-    #            return local_directory[0]
-
-    #    if 'region' in self.account_conf:
-    #        return self.account_conf.get('region')
-    #    if 'region' in self.common_conf:
-    #        return self.common_conf.get('region')
-    #    if 'region_primary' in self.account_conf:
-    #        return self.account_conf.get('region_primary')
-    #    if 'region_primary' in self.common_conf:
-    #        return self.common_conf.get('region_primary')
-
-    #    return None
-
     def set_backend_key(self, skip_validation=False):
         # Scenarios:
         #

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -428,7 +428,6 @@ class TerraformContainer(LeverageContainer):
         self.mounts = [
             Mount(source=self.root_dir.as_posix(), target=self.guest_base_path, type="bind"),
             Mount(source=self.host_aws_credentials_dir.as_posix(), target=self.guest_aws_credentials_dir, type="bind"),
-            #Mount(source=(self.home / ".ssh").as_posix(), target="/root/.ssh", type="bind"),
             Mount(source=(self.home / ".gitconfig").as_posix(), target="/etc/gitconfig", type="bind")
         ]
         if not SSH_AUTH_SOCK is None:

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -430,7 +430,7 @@ class TerraformContainer(LeverageContainer):
             Mount(source=self.host_aws_credentials_dir.as_posix(), target=self.guest_aws_credentials_dir, type="bind"),
             Mount(source=(self.home / ".gitconfig").as_posix(), target="/etc/gitconfig", type="bind")
         ]
-        if not SSH_AUTH_SOCK is None:
+        if SSH_AUTH_SOCK is not None:
             self.mounts.append(Mount(source=SSH_AUTH_SOCK, target="/ssh-agent", type="bind"))
 
         self._backend_key = None

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -586,52 +586,52 @@ class TerraformContainer(LeverageContainer):
         self._prepare_container()
         self._start()
 
-    @property
-    def region(self):
-        """ Determine the region based on PATH, account tfvars or project tfvars. Returns a string with the region name. """
-        region = self._find_region(self.cwd.relative_to(self.account_dir))
+    #@property
+    #def region(self):
+    #    """ Determine the region based on PATH, account tfvars or project tfvars. Returns a string with the region name. """
+    #    region = self._find_region(self.cwd.relative_to(self.account_dir))
 
-        if not region is None:
-            return region
+    #    if not region is None:
+    #        return region
 
-        logger.error("No region found")
-        raise Exit(1)
+    #    logger.error("No region found")
+    #    raise Exit(1)
 
-    @property
-    def terraform_backend(self):
-        """ Determine the terraform backend for the account. Returns an object with backend information. """
-        # These are the possible backend layer names for Refarch v1 and v2
-        possible_layer_names = ['terraform-backend', 'base-tf-backend']
-        for layer_name in possible_layer_names:
-            for directory in Path(self.account_dir).glob(f"**/{layer_name}"):
+    #@property
+    #def terraform_backend(self):
+    #    """ Determine the terraform backend for the account. Returns an object with backend information. """
+    #    # These are the possible backend layer names for Refarch v1 and v2
+    #    possible_layer_names = ['terraform-backend', 'base-tf-backend']
+    #    for layer_name in possible_layer_names:
+    #        for directory in Path(self.account_dir).glob(f"**/{layer_name}"):
 
-                region = self._find_region(Path(directory).relative_to(self.account_dir))
+    #            region = self._find_region(Path(directory).relative_to(self.account_dir))
 
-                if not region is None:
-                    return {'directory': directory , 'region': region}
-                else:
-                    logger.error("No region found for backend layer")
-                    raise Exit(1)
+    #            if not region is None:
+    #                return {'directory': directory , 'region': region}
+    #            else:
+    #                logger.error("No region found for backend layer")
+    #                raise Exit(1)
 
-        logger.error("No backend layer found")
-        raise Exit(1)
+    #    logger.error("No backend layer found")
+    #    raise Exit(1)
 
-    def _find_region(self, local_directory):
-        local_directory = local_directory.as_posix().split('/')
-        if len(local_directory) > 1:
-            if local_directory[0] != 'global':
-                return local_directory[0]
+    #def _find_region(self, local_directory):
+    #    local_directory = local_directory.as_posix().split('/')
+    #    if len(local_directory) > 1:
+    #        if local_directory[0] != 'global':
+    #            return local_directory[0]
 
-        if 'region' in self.account_conf:
-            return self.account_conf.get('region')
-        if 'region' in self.common_conf:
-            return self.common_conf.get('region')
-        if 'region_primary' in self.account_conf:
-            return self.account_conf.get('region_primary')
-        if 'region_primary' in self.common_conf:
-            return self.common_conf.get('region_primary')
+    #    if 'region' in self.account_conf:
+    #        return self.account_conf.get('region')
+    #    if 'region' in self.common_conf:
+    #        return self.common_conf.get('region')
+    #    if 'region_primary' in self.account_conf:
+    #        return self.account_conf.get('region_primary')
+    #    if 'region_primary' in self.common_conf:
+    #        return self.common_conf.get('region_primary')
 
-        return None
+    #    return None
 
     def set_backend_key(self, skip_validation=False):
         # Scenarios:

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -282,7 +282,7 @@ def _init(tf, args):
     args = [arg for index, arg in enumerate(args)
             if not arg.startswith("-backend-config") or not arg[index - 1] == "-backend-config"]
     args.append(f"-backend-config={tf.backend_tfvars}")
-    args.append(f"-backend-config=\"region={tf.terraform_backend.get('region')}\"")
+    #args.append(f"-backend-config=\"region={tf.terraform_backend.get('region')}\"")
 
     exit_code = tf.start_in_layer("init", *args)
 

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -433,7 +433,7 @@ def _validate_layout(tf):
         logger.info("[green]✔ OK[/green]\n")
     else:
         exp_message = [f"{'/'.join(x)}/terraform.tfstate" for x in expected_backend_keys]
-        logger.info(f"Expected on of: {';'.join(exp_message)}")
+        logger.info(f"Expected one of: {';'.join(exp_message)}")
         logger.error("[red]✘ FAILED[/red]\n")
         valid_layout = False
 

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -282,7 +282,6 @@ def _init(tf, args):
     args = [arg for index, arg in enumerate(args)
             if not arg.startswith("-backend-config") or not arg[index - 1] == "-backend-config"]
     args.append(f"-backend-config={tf.backend_tfvars}")
-    #args.append(f"-backend-config=\"region={tf.terraform_backend.get('region')}\"")
 
     exit_code = tf.start_in_layer("init", *args)
 


### PR DESCRIPTION
## what
* The way the `.ssh` dir is mounted into the container was changed from
  * mount ~/.ssh -> ~/.ssh
* to:
  * mount ~/.ssh -> /tmp/.ssh
  * cp -r /tmp/.ssh ~/
  * chown to container user and chmod to 600

## why
* If the `.ssh` files are owned by other than the current container user, or the config file has permissions other than `600` the `bad owner permissions issue` is got.

## references
* solves https://github.com/binbashar/leverage/issues/173

## Before release
* Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)

