### PR TITLE
the package is missing the containers module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 packages =
     leverage
     leverage/modules
+    leverage/containers
 python_requires = >= 3.8
 install_requires = 
     yaenv == 1.4.1


### PR DESCRIPTION
## What?
A fix for a bug introduced in https://github.com/binbashar/leverage/pull/172

## Why?
```
>> leverage --version
Traceback (most recent call last):
  File "/usr/local/bin/leverage", line 5, in <module>
    from leverage import leverage
  File "/home/frivera/.local/lib/python3.10/site-packages/leverage/__init__.py", line 18, in <module>
    from leverage.leverage import leverage
  File "/home/frivera/.local/lib/python3.10/site-packages/leverage/leverage.py", line 11, in <module>
    from leverage.modules import aws
  File "/home/frivera/.local/lib/python3.10/site-packages/leverage/modules/__init__.py", line 7, in <module>
    from .kubectl import kubectl
  File "/home/frivera/.local/lib/python3.10/site-packages/leverage/modules/kubectl.py", line 4, in <module>
    from leverage.containers.kubectl import KubeCtlContainer
ModuleNotFoundError: No module named 'leverage.containers'
```