### PR TITLE
[126] Kubectl: remove unnecessary shenanigans for MFA

### DIFF
--- a/leverage/_utils.py
+++ b/leverage/_utils.py
@@ -103,11 +103,6 @@ def refresh_aws_credentials(func):
             auth_method = container.TF_SSO_ENTRYPOINT
         elif container.mfa_enabled:
             auth_method = container.TF_MFA_ENTRYPOINT
-            # TODO: ask why this was necessary
-            container.environment.update({
-                "AWS_SHARED_CREDENTIALS_FILE": container.environment["AWS_SHARED_CREDENTIALS_FILE"].replace("tmp", ".aws"),
-                "AWS_CONFIG_FILE": container.environment["AWS_CONFIG_FILE"].replace("tmp", ".aws"),
-            })
         else:
             # no auth method found: skip the refresh
             return func(*args, **kwargs)
@@ -119,13 +114,6 @@ def refresh_aws_credentials(func):
             exit_code = container._start("Fetching done.")
             if exit_code:
                 raise Exit(exit_code)
-            if container.mfa_enabled:
-                # we need to revert to the original values, otherwise other tools that rely on awscli, like kubectl
-                # won't find the credentials
-                container.environment.update({
-                    "AWS_SHARED_CREDENTIALS_FILE": container.environment["AWS_SHARED_CREDENTIALS_FILE"].replace(".aws", "tmp"),
-                    "AWS_CONFIG_FILE": container.environment["AWS_CONFIG_FILE"].replace(".aws", "tmp"),
-                })
 
         # we should have a valid token at this point, now execute the original method
         return func(*args, **kwargs)

--- a/leverage/_utils.py
+++ b/leverage/_utils.py
@@ -89,28 +89,6 @@ class EmptyEntryPoint(CustomEntryPoint):
         super(EmptyEntryPoint, self).__init__(container, entrypoint="")
 
 
-class AwsCredsEntryPoint(CustomEntryPoint):
-    """
-    Fetching AWS credentials with setting the SSO/MFA entrypoints.
-    This works as a replacement of _prepare_container.
-    """
-
-    def __init__(self, container):
-        if container.sso_enabled:
-            container._check_sso_token()
-            auth_method = f"{container.TF_SSO_ENTRYPOINT} -- "
-        elif container.mfa_enabled:
-            auth_method = f"{container.TF_MFA_ENTRYPOINT} -- "
-            container.environment.update({
-                "AWS_SHARED_CREDENTIALS_FILE": container.environment["AWS_SHARED_CREDENTIALS_FILE"].replace("tmp", ".aws"),
-                "AWS_CONFIG_FILE": container.environment["AWS_CONFIG_FILE"].replace("tmp", ".aws"),
-            })
-        else:
-            auth_method = ""
-
-        super(AwsCredsEntryPoint, self).__init__(container, entrypoint=auth_method)
-
-
 def refresh_aws_credentials(func):
     """
     Use this decorator in the case you want to make sure you will have fresh tokens to interact with AWS

--- a/leverage/_utils.py
+++ b/leverage/_utils.py
@@ -1,13 +1,8 @@
 """
     General use utilities.
 """
-import functools
 from subprocess import run
 from subprocess import PIPE
-
-from click.exceptions import Exit
-
-from leverage import logger
 
 
 def clean_exception_traceback(exception):
@@ -62,38 +57,48 @@ def chain_commands(commands: list, chain: str = " && ") -> str:
     return f"bash -c \"{chain.join(commands)}\""
 
 
-def refresh_aws_credentials(entrypoint=None):
+class CustomEntryPoint:
     """
-    Use this decorator in the case you want to make sure you will have fresh tokens to interact with AWS
-    during the execution of all the command inside the wrapped method.
-    The difference with _prepare_container is that it let you don't use the default entrypoint of the class
-    in case you need to execute different binaries during a single command.
+    Set a custom entrypoint on the container while entering the context.
+    Once outside, return it to its original value.
     """
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            container = args[0]  # this is the "self" of the method you are decorating; a LeverageContainer instance
+    def __init__(self, container, entrypoint):
+        self.container = container
+        self.old_entrypoint = container.entrypoint
+        self.new_entrypoint = entrypoint
 
-            if container.sso_enabled:
-                container._check_sso_token()
-                auth_method = container.TF_SSO_ENTRYPOINT
-            elif container.mfa_enabled:
-                auth_method = container.TF_MFA_ENTRYPOINT
-                container.environment.update({
-                    "AWS_SHARED_CREDENTIALS_FILE": container.environment["AWS_SHARED_CREDENTIALS_FILE"].replace("tmp", ".aws"),
-                    "AWS_CONFIG_FILE": container.environment["AWS_CONFIG_FILE"].replace("tmp", ".aws"),
-                })
-            else:
-                # no auth method required: don't prepend any script then
-                auth_method = None
+    def __enter__(self):
+        self.container.entrypoint = self.new_entrypoint
 
-            new_entrypoint = entrypoint if entrypoint is not None else container.entrypoint
-            container.entrypoint = f"{auth_method} -- {new_entrypoint}" if auth_method else new_entrypoint
-            # from now one, every call to a command will be preceded by the MFA/SSO scripts
-            # making sure you have fresh credentials before executing them
-            return func(*args, **kwargs)
+    def __exit__(self, *args, **kwargs):
+        self.container.entrypoint = self.old_entrypoint
 
-        return wrapper
 
-    return decorator
+class AwsCredsEntryPoint(CustomEntryPoint):
+    """
+    Fetching AWS credentials by setting the SSO/MFA entrypoints.
+    This works as a replacement of _prepare_container.
+    """
 
+    def __init__(self, container):
+        if container.sso_enabled:
+            container._check_sso_token()
+            auth_method = f"{container.TF_SSO_ENTRYPOINT} -- "
+        elif container.mfa_enabled:
+            auth_method = f"{container.TF_MFA_ENTRYPOINT} -- "
+            container.environment.update({
+                "AWS_SHARED_CREDENTIALS_FILE": container.environment["AWS_SHARED_CREDENTIALS_FILE"].replace("tmp", ".aws"),
+                "AWS_CONFIG_FILE": container.environment["AWS_CONFIG_FILE"].replace("tmp", ".aws"),
+            })
+        else:
+            auth_method = ""
+
+        super(AwsCredsEntryPoint, self).__init__(container, entrypoint=auth_method)
+
+    def __exit__(self, *args, **kwargs):
+        super(AwsCredsEntryPoint, self).__exit__(*args, **kwargs)
+        if self.container.mfa_enabled:
+            self.container.environment.update({
+                "AWS_SHARED_CREDENTIALS_FILE": self.container.environment["AWS_SHARED_CREDENTIALS_FILE"].replace(".aws", "tmp"),
+                "AWS_CONFIG_FILE": self.container.environment["AWS_CONFIG_FILE"].replace(".aws", "tmp"),
+            })

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from pathlib import Path
 from datetime import datetime
 
@@ -20,6 +21,15 @@ from leverage.path import get_global_config_path
 from leverage.path import get_account_config_path
 from leverage.path import NotARepositoryError
 from leverage.conf import load as load_env
+
+REGION = (
+    r"(.*)"  # project folder
+    # start region 
+    r"(global|(?:[a-z]{2}-(?:gov-)?"
+    r"(?:central|north|south|east|west|northeast|northwest|southeast|southwest|secret|topsecret)-[1-4]))"
+    # end region
+    r"(.*)"  # layer
+)
 
 
 def get_docker_client():
@@ -67,7 +77,6 @@ class LeverageContainer:
         self.client = client
 
         self.home = Path.home()
-        self.cwd = Path.cwd()
         try:
             self.root_dir = Path(get_root_path())
             self.account_dir = Path(get_account_path())
@@ -166,6 +175,22 @@ class LeverageContainer:
     @property
     def guest_aws_credentials_dir(self):
         return f"/root/tmp/{self.project}"
+
+    @property
+    def cwd(self):
+        return Path.cwd()
+
+    @property
+    def region(self):
+        """
+        Return the region of the layer.
+        """
+        if matches := re.match(REGION, self.cwd.as_posix()):
+            # the region (group 1) is between the projects folders (group 0) and the layers (group 2)
+            return matches.groups()[1]
+
+        logger.exception(f"No valid region could be found at: {self.cwd.as_posix()}")
+        raise Exit(1)
 
     def ensure_image(self):
         """ Make sure the required Docker image is available in the system. If not, pull it from registry. """

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -269,6 +269,20 @@ class LeverageContainer:
 
         return self._run(container, run_func)
 
+    def _start_with_output(self, command="/bin/bash", *args):
+        """
+        Same than _start but also returns the outputs (by dumping the logs) of the container.
+        """
+        container = self._create_container(True, command, *args)
+
+        def run_func(client, container):
+            dockerpty.start(client=client.api, container=container)
+            exit_code = client.api.inspect_container(container)["State"]["ExitCode"]
+            logs = client.api.logs(container).decode("utf-8")
+            return exit_code, logs
+
+        return self._run(container, run_func)
+
     def start(self, command="/bin/sh", *arguments):
         """ Run command with the given arguments in an interactive container.
 

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -77,6 +77,7 @@ class LeverageContainer:
         self.client = client
 
         self.home = Path.home()
+        self.cwd = Path.cwd()
         try:
             self.root_dir = Path(get_root_path())
             self.account_dir = Path(get_account_path())
@@ -175,10 +176,6 @@ class LeverageContainer:
     @property
     def guest_aws_credentials_dir(self):
         return f"/root/tmp/{self.project}"
-
-    @property
-    def cwd(self):
-        return Path.cwd()
 
     @property
     def region(self):

--- a/leverage/containers/kubectl.py
+++ b/leverage/containers/kubectl.py
@@ -36,11 +36,11 @@ class KubeCtlContainer(TerraformContainer):
             )
         )
 
-    @refresh_aws_credentials
+    @refresh_aws_credentials(entrypoint="")
     def start_shell(self):
-        self._start(command="/bin/bash")
+        self._start("/bin/bash")
 
-    @refresh_aws_credentials
+    @refresh_aws_credentials(entrypoint="")
     def configure(self):
         # make sure we are on the cluster layer
         self.check_for_layer_location()

--- a/leverage/containers/kubectl.py
+++ b/leverage/containers/kubectl.py
@@ -67,8 +67,7 @@ class KubeCtlContainer(TerraformContainer):
             raise Exit(exit_code)
 
         aws_eks_cmd = next(op for op in output.split("\r\n") if op.startswith("aws eks update-kubeconfig"))
-        # assuming the cluster container is on the primary region
-        return aws_eks_cmd + f" --region {self.common_conf['region_primary']}"
+        return aws_eks_cmd + f" --region {self.region}"
 
     def _get_user_group_id(self, user_id) -> int:
         user = pwd.getpwuid(user_id)

--- a/leverage/containers/kubectl.py
+++ b/leverage/containers/kubectl.py
@@ -22,7 +22,11 @@ class KubeCtlContainer(TerraformContainer):
 
         self.entrypoint = self.KUBECTL_CLI_BINARY
 
-        host_config_path = str(Path.home() / Path(f".kube/{self.project}"))
+        self.host_kubectl_config_dir = Path.home() / Path(f".kube/{self.project}")
+        if not self.host_kubectl_config_dir.exists():
+            # make sure the folder exists before mounting it
+            self.host_kubectl_config_dir.mkdir(parents=True)
+
         self.container_config["host_config"]["Mounts"].append(
             # the container is expecting a file named "config" here
             Mount(

--- a/leverage/containers/kubectl.py
+++ b/leverage/containers/kubectl.py
@@ -6,7 +6,7 @@ from click.exceptions import Exit
 from docker.types import Mount
 
 from leverage import logger
-from leverage._utils import chain_commands, refresh_aws_credentials
+from leverage._utils import chain_commands, AwsCredsEntryPoint
 from leverage.container import TerraformContainer
 
 
@@ -36,24 +36,25 @@ class KubeCtlContainer(TerraformContainer):
             )
         )
 
-    @refresh_aws_credentials(entrypoint="")
     def start_shell(self):
-        self._start("/bin/bash")
+        with AwsCredsEntryPoint(self):
+            self._start("/bin/bash")
 
-    @refresh_aws_credentials(entrypoint="")
     def configure(self):
         # make sure we are on the cluster layer
         self.check_for_layer_location()
 
         logger.info("Retrieving k8s cluster information...")
         # generate the command that will configure the new cluster
-        add_eks_cluster_cmd = self._get_eks_kube_config()
+        with AwsCredsEntryPoint(self):
+            add_eks_cluster_cmd = self._get_eks_kube_config()
         # and the command that will set the proper ownership on the config file (otherwise the owner will be "root")
         change_owner_cmd = self._change_kube_file_owner_cmd()
         full_cmd = chain_commands([add_eks_cluster_cmd, change_owner_cmd])
 
         logger.info("Configuring context...")
-        exit_code = self._start(full_cmd)
+        with AwsCredsEntryPoint(self):
+            exit_code = self._start(full_cmd)
         if exit_code:
             raise Exit(exit_code)
 

--- a/leverage/containers/kubectl.py
+++ b/leverage/containers/kubectl.py
@@ -6,7 +6,7 @@ from click.exceptions import Exit
 from docker.types import Mount
 
 from leverage import logger
-from leverage._utils import chain_commands, AwsCredsEntryPoint, refresh_aws_credentials
+from leverage._utils import chain_commands, refresh_aws_credentials
 from leverage.container import TerraformContainer
 
 

--- a/tests/test_containers/test_kubectl.py
+++ b/tests/test_containers/test_kubectl.py
@@ -125,8 +125,11 @@ def test_start_shell_mfa(kubectl_container):
     # container._run = Mock()
 
     kubectl_container.enable_mfa()
-    kubectl_container.start_shell()
-    container_args = kubectl_container.client.api.create_container.call_args[1]
+    # mock the __exit__ of the context manager to avoid the restoration of the values
+    # otherwise the asserts around /.aws/ wouldn't be possible
+    with patch("leverage._utils.AwsCredsEntryPoint.__exit__"):
+        kubectl_container.start_shell()
+        container_args = kubectl_container.client.api.create_container.call_args[1]
 
     # we want a shell, so -> /bin/bash with no entrypoint
     assert container_args["command"] == "/bin/bash"

--- a/tests/test_containers/test_kubectl.py
+++ b/tests/test_containers/test_kubectl.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch, PropertyMock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from click.exceptions import Exit

--- a/tests/test_containers/test_kubectl.py
+++ b/tests/test_containers/test_kubectl.py
@@ -33,8 +33,8 @@ def kubectl_container(muted_click_context):
 
 
 def test_get_eks_kube_config(kubectl_container):
-    tf_output = "\naws eks update-kubeconfig --name test-cluster --profile test-profile\n"
-    with patch.object(kubectl_container, "_exec", return_value=(0, tf_output)):
+    tf_output = "\r\naws eks update-kubeconfig --name test-cluster --profile test-profile\r\n"
+    with patch.object(kubectl_container, "_start_with_output", return_value=(0, tf_output)):
         kubectl_container.common_conf["region_primary"] = "us-east-1"
         cmd = kubectl_container._get_eks_kube_config()
 
@@ -45,7 +45,7 @@ def test_get_eks_kube_config_tf_output_error(kubectl_container):
     """
     Test that if the TF OUTPUT fails, we get an error back.
     """
-    with patch.object(kubectl_container, "_exec", return_value=(1, "ERROR!")):
+    with patch.object(kubectl_container, "_start_with_output", return_value=(1, "ERROR!")):
         with pytest.raises(Exit):
             kubectl_container._get_eks_kube_config()
 

--- a/tests/test_containers/test_kubectl.py
+++ b/tests/test_containers/test_kubectl.py
@@ -85,7 +85,7 @@ def test_start_shell(kubectl_container):
     container_args = kubectl_container.client.api.create_container.call_args[1]
 
     # we want a shell, so -> /bin/bash with no entrypoint
-    assert container_args["command"] == "/bin/sh"
+    assert container_args["command"] == "/bin/bash"
     assert container_args["entrypoint"] == ""
 
     # make sure we are pointing to the AWS credentials
@@ -106,8 +106,50 @@ def test_start_shell(kubectl_container):
 @patch.object(KubeCtlContainer, "check_for_layer_location", Mock())
 # nor terraform
 @patch.object(KubeCtlContainer, "_get_eks_kube_config", Mock(return_value=AWS_EKS_UPDATE_KUBECONFIG))
-def test_configure(kubectl_container, caplog):
+def test_configure(kubectl_container):
     with patch.object(kubectl_container, "_start", return_value=0) as mock_start:
         kubectl_container.configure()
 
     assert mock_start.call_args[0][0] == f'bash -c "{AWS_EKS_UPDATE_KUBECONFIG} && chown 1234:5678 /root/.kube/config"'
+
+
+#####################
+# test auth methods #
+#####################
+
+def test_start_shell_mfa(kubectl_container):
+    """
+    Make sure the command is executed through the proper MFA script.
+    """
+    # container = KubeCtlContainer(docker_client, env_conf=dict(MFA_ENABLED="true", **FAKE_ENV))
+    # container._run = Mock()
+
+    kubectl_container.enable_mfa()
+    kubectl_container.start_shell()
+    container_args = kubectl_container.client.api.create_container.call_args[1]
+
+    # we want a shell, so -> /bin/bash with no entrypoint
+    assert container_args["command"] == "/bin/bash"
+    assert container_args["entrypoint"] == "/root/scripts/aws-mfa/aws-mfa-entrypoint.sh -- "
+
+    # make sure we are pointing to the right AWS credentials: /.aws/ folder for MFA
+    assert container_args["environment"]["AWS_CONFIG_FILE"] == "/root/.aws/test/config"
+    assert container_args["environment"]["AWS_SHARED_CREDENTIALS_FILE"] == "/root/.aws/test/credentials"
+
+
+def test_start_shell_sso(kubectl_container):
+    """
+    Make sure the command is executed through the proper SSO script.
+    """
+    kubectl_container.enable_sso()
+    kubectl_container._check_sso_token = Mock(return_value=True)
+    kubectl_container.start_shell()
+    container_args = kubectl_container.client.api.create_container.call_args[1]
+
+    # we want a shell, so -> /bin/bash with no entrypoint
+    assert container_args["command"] == "/bin/bash"
+    assert container_args["entrypoint"] == "/root/scripts/aws-sso/aws-sso-entrypoint.sh -- "
+
+    # make sure we are pointing to the right AWS credentials: /tmp/ folder for SSO
+    assert container_args["environment"]["AWS_CONFIG_FILE"] == "/root/tmp/test/config"
+    assert container_args["environment"]["AWS_SHARED_CREDENTIALS_FILE"] == "/root/tmp/test/credentials"

--- a/tests/test_containers/test_kubectl.py
+++ b/tests/test_containers/test_kubectl.py
@@ -32,10 +32,10 @@ def kubectl_container(muted_click_context):
 ##############
 
 
-@patch.object(KubeCtlContainer, "cwd", PropertyMock(return_value=Path("/project/account/us-east-1/cluster")))
 def test_get_eks_kube_config(kubectl_container):
     tf_output = "\r\naws eks update-kubeconfig --name test-cluster --profile test-profile\r\n"
     with patch.object(kubectl_container, "_start_with_output", return_value=(0, tf_output)):
+        kubectl_container.cwd = Path("/project/account/us-east-1/cluster")
         cmd = kubectl_container._get_eks_kube_config()
 
     assert cmd == AWS_EKS_UPDATE_KUBECONFIG
@@ -56,7 +56,6 @@ def test_change_kube_file_owner_cmd(kubectl_container):
         assert kubectl_container._change_kube_file_owner_cmd() == "chown 1234:5678 /root/.kube/config"
 
 
-@patch.object(KubeCtlContainer, "cwd", PropertyMock(return_value=Path("/random")))
 def test_check_for_layer_location(kubectl_container, caplog):
     """
     Test that if we are not on a cluster layer, we raise an error.
@@ -66,6 +65,7 @@ def test_check_for_layer_location(kubectl_container, caplog):
 
     with patch.object(TerraformContainer, "check_for_layer_location"):  # assume parent method is already tested
         with pytest.raises(Exit):
+            kubectl_container.cwd = Path("/random")
             kubectl_container.check_for_layer_location()
 
     assert caplog.messages[0] == "This command can only run at the [bold]cluster layer[/bold]."


### PR DESCRIPTION
## What?
While trying https://github.com/binbashar/leverage/pull/172 with an MFA account, I found out that it wasn't working.
The command was not able to find credentials while trying to run commands inside the container. 
I was because of the `.aws` folder been ephemeral during the run of the commands.
So you have to call the MFA logic everytime you need to run AWS related commands.

## Why?
```
[12:45:11.610] INFO     Fetching  AWS credentials...                                                                                                                                   
[15:45:11]   INFO	MFA: Found 2 profile/s
[15:45:11]   INFO	MFA: Attempting to get temporary credentials for profile cdot-apps-devstg-devops
[15:45:13]   INFO	MFA: Using cached credentials
[15:45:15]   INFO	MFA: Credentials written succesfully!
[15:45:15]   INFO	MFA: Attempting to get temporary credentials for profile cdot-shared-devops
[15:45:16]   INFO	MFA: Using cached credentials
[15:45:18]   INFO	MFA: Credentials written succesfully!
Fetching done.
[12:45:19.056] INFO     Retrieving k8s cluster information...                                                                                                                          
[12:45:25.808] ERROR    [31m╷[0m[0m                                                                                                                                                    
                        [31m│[0m [0m[1m[31mError: [0m[0m[1merror configuring S3 Backend: no valid credential sources for S3 Backend found.                                             
                        [31m│[0m [0m                                                                                                                                                   
                        [31m│[0m [0mPlease see https://www.terraform.io/docs/language/settings/backends/s3.html                                                                        
                        [31m│[0m [0mfor more information about providing credentials.                                                                                                  
                        [31m│[0m [0m                                                                                                                                                   
                        [31m│[0m [0mError: NoCredentialProviders: no valid providers in chain. Deprecated.                                                                             
                        [31m│[0m [0m For verbose messaging see aws.Config.CredentialsChainVerboseErrors                                                                                
                        [31m│[0m [0m[0m                                                                                                                                                
                        [31m│[0m [0m                                                                                                                                                   
                        [31m│[0m [0m[0m                                                                                                                                                
                        [31m╵[0m[0m                                                                                                                                                    
```
