### PR TITLE
Add SSO layer to provision the landing zone with that by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For the second item you can check the version [here](https://hub.docker.com/r/bi
 
 First, you should create a virtual environment and install all the required dependencies by running: `pipenv install --dev`.
 
-If you don't have `pipenv` in your system, you can check the following documentation: https://pipenv.pypa.io/en/latest/install/#installing-pipenv
+If you don't have `pipenv` in your system, you can check the following documentation: https://pipenv.pypa.io/en/latest/#install-pipenv-today
 
 Once you have everything in place, install the CLI as an editable package inside the virtual environment: `pipenv install -e .` 
 

--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -4,7 +4,7 @@
 #pylint: disable=wrong-import-position
 
 __version__ = "0.0.0"
-__toolbox_version__ = "1.2.7-0.1.0"
+__toolbox_version__ = "1.2.7-0.1.6"
 
 import sys
 from shutil import which

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -45,7 +45,8 @@ PROJECT_STRUCTURE = {
     "management": {
         "global": [
             "base-identities",
-            "organizations"
+            "organizations",
+            "sso"
         ],
         "primary_region": [
             "base-tf-backend",


### PR DESCRIPTION
## What?
* Add SSO layer to provision the landing zone with that by default.

## Why?
* The Landing Zone now uses SSO by default.

## References
TBD

## Before release
Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)
