### PR TITLE
renaming github workflows files and the actions names in order to be …

### DIFF
--- a/.github/workflows/release-management-github.yml
+++ b/.github/workflows/release-management-github.yml
@@ -1,4 +1,4 @@
-name: Release Management
+name: Release | Github Release
 
 on:
   push:

--- a/.github/workflows/release-management-github.yml
+++ b/.github/workflows/release-management-github.yml
@@ -1,4 +1,4 @@
-name: Release | Github Release
+name: Release | Github Release Drafter
 
 on:
   push:

--- a/.github/workflows/release-pypi-build-push-package.yml
+++ b/.github/workflows/release-pypi-build-push-package.yml
@@ -1,4 +1,4 @@
-name: Build Package and Push
+name: Release | PyPi Build Package and Push
 
 on:
   release:

--- a/.github/workflows/release-pypi-build-push-test-package.yml
+++ b/.github/workflows/release-pypi-build-push-test-package.yml
@@ -1,4 +1,4 @@
-name: Test Build Package and Push
+name: Release | PyPi Build Test Package and Push
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-lint-black.yaml
+++ b/.github/workflows/test-lint-black.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: Tests | Lint w/ Black
 
 on: [push, pull_request]
 

--- a/.github/workflows/tests-unit-and-integration.yml
+++ b/.github/workflows/tests-unit-and-integration.yml
@@ -1,4 +1,4 @@
-name: Run tests 
+name: Tests | Unit and Integration
 
 on: [pull_request, workflow_dispatch]
 


### PR DESCRIPTION
## What?

###  Commits on Apr 28, 2023
- [renaming github workflows files and the actions names in order to be more intuitive](https://github.com/binbashar/leverage/commit/033f1a486b5cc3000e05b9ba26c12b78303832b3)
- [More explicit name for the GH Release drafter](https://github.com/binbashar/leverage/pull/198/commits/b14691468ccd0a6dc3e7d467ff4b6947afcc06bc)

## Why?
- Easier to understand and to speed up the on boarding / ramp-up
- Standardize the naming under a 1st possible convention

