### PR TITLE
[205] Push pre-releases builds to the official pypi

### DIFF
--- a/.github/workflows/release-pypi-build-push-test-package.yml
+++ b/.github/workflows/release-pypi-build-push-test-package.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: upload
         run: |
-          pipenv run twine upload --non-interactive --repository testpypi dist/*
+          pipenv run twine upload --non-interactive --repository-url https://upload.pypi.org/legacy/ dist/*
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TESTPYPI_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To run all tests, run `make tests`. Alternatively `make test-unit` or `make test
 * There is an Action called "Test Build Package and Push".
 * This Action can be called manually on any branch specifying the version to release to test.
     * The version is a Release Candidate following the Semver: e.g. if the next release is 1.2.3, the test version should be 1.2.3-rc.1
-* The package will be published to [Test PyPi](https://test.pypi.org/project/leverage/).
+* The package will be published to [PyPi](https://pypi.org/project/leverage/).
 
 ## Contributors/Contributing
 * Leverage CLI was initially based on Pynt: https://github.com/rags/pynt


### PR DESCRIPTION
## What?
We decided to push the pre-releases version of Leverage directly to the [official Package Index](https://pypi.org/) (instead of the [testing one](https://test.pypi.org/)).

## Why?
Because they support pre-releases versions (you have to use the `--pre` flag on pip). So it doesn't make any sense to use 2 different package indexes. 
