### PR TITLE
Increase verbosity from 2 to 3 levels

### DIFF
--- a/leverage/container.py
+++ b/leverage/container.py
@@ -481,7 +481,7 @@ class AWSCLIContainer(LeverageContainer):
             link = self.AWS_SSO_LOGIN_URL.format(region=region.strip(), user_code=user_code)
             webbrowser.open_new_tab(link)
             # The SSO code is only valid once: if the browser was able to open it, the fallback link will be invalid
-            logger.info(self.FALLBACK_LINK_MSG.format(link=link))
+            logger.warning(self.FALLBACK_LINK_MSG.format(link=link))
             # now let's wait until the command locking the container resolve itself:
             # aws sso login will wait for the user code
             # once submitted to the browser, the authentication finish and the lock is released

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -26,7 +26,7 @@ from leverage.modules import kubectl
     help="Name of the build file containing the tasks definitions.",
 )
 @click.option("--list-tasks", "-l", is_flag=True, help="List available tasks to run.")
-@click.option("-v", "--verbose", is_flag=True, help="Increase output verbosity.")
+@click.option("-v", "--verbose", count=True, help="Select output verbosity.")
 @click.version_option(version=__version__)
 @pass_state
 @click.pass_context

--- a/leverage/logger.py
+++ b/leverage/logger.py
@@ -20,7 +20,7 @@ _leverage_logger = logging.getLogger("leverage")
 
 
 LOGGING_LEVELS = {
-    0: logging.ERROR,
+    0: logging.WARNING,
     1: logging.INFO,
     2: logging.DEBUG,
 }
@@ -42,7 +42,7 @@ def get_script_log_level():
         int: Logging level as defined in the Leverage scripts.
     """
     log_level = {
-        logging.ERROR: 1,
+        logging.WARNING: 1,
         logging.INFO: 2,
         logging.DEBUG: 3,
     }

--- a/leverage/logger.py
+++ b/leverage/logger.py
@@ -19,6 +19,12 @@ _TIME_FORMAT = lambda time: f"[{time:%H:%M:%S}.{time.microsecond//1000:03}]"
 _leverage_logger = logging.getLogger("leverage")
 
 
+LOGGING_LEVELS = {
+    0: logging.ERROR,
+    1: logging.INFO,
+    2: logging.DEBUG,
+}
+
 # Use the same console for the logging handler and any other special cases like
 # spinners, tables or progress bars.
 # TODO: Deprecate in favor of using rich's global console.
@@ -45,16 +51,14 @@ def get_script_log_level():
     return log_level[verbosity]
 
 
-def get_verbosity(verbose):
+def get_verbosity(verbose: int):
     """Transform the given verbosity level into the corresponding logging level.
-
-    Args:
-        verbose (bool): Whether the logging should be verbose or not
 
     Returns:
         int: Logging level
     """
-    return logging.DEBUG if verbose else logging.INFO
+    verbose = 2 if verbose > 2 else verbose
+    return LOGGING_LEVELS[verbose]
 
 
 def _configure_logger(logger, show_level=True):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def dir_structure(monkeypatch, tmp_path):
 
 @pytest.fixture
 def click_context():
-    def context(verbose=True, build_script_name="build.py"):
+    def context(verbose=2, build_script_name="build.py"):
         state = State()
         state.verbosity = verbose
         state.module = Module(name=build_script_name)
@@ -46,7 +46,7 @@ def with_click_context(click_context):
 
 @pytest.fixture
 def muted_click_context(click_context):
-    with click_context(verbose=False):
+    with click_context(verbose=0):
         yield
 
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -18,7 +18,14 @@ INFO = logging.getLevelName("INFO")
 WARNING = logging.getLevelName("WARNING")
 
 
-@pytest.mark.parametrize("verbose, expected_value", [(True, 3), (False, 2)])
+@pytest.mark.parametrize(
+    "verbose, expected_value",
+    [
+        (2, 3),  # debug
+        (1, 2),  # info
+        (0, 1),  # warning
+    ],
+)
 def test_get_script_log_level(click_context, verbose, expected_value):
     with click_context(verbose=verbose):
         log_level = get_script_log_level()
@@ -27,22 +34,23 @@ def test_get_script_log_level(click_context, verbose, expected_value):
 
 
 def test_get_verbosity():
-    assert get_verbosity(verbose=True) == DEBUG
-    assert get_verbosity(verbose=False) == INFO
+    assert get_verbosity(verbose=2) == DEBUG
+    assert get_verbosity(verbose=1) == INFO
+    assert get_verbosity(verbose=0) == WARNING
 
 
 def test__configure_logger(click_context):
-    with click_context(verbose=False):
+    with click_context(verbose=0):
         logger = logging.getLogger("build")
 
         _configure_logger(logger)
 
-        assert logger.level == INFO
+        assert logger.level == WARNING
         assert len(logger.handlers) == 1
 
         handler = logger.handlers[0]
         assert isinstance(handler, RichHandler)
-        assert handler.level == INFO
+        assert handler.level == WARNING
 
 
 def test_initialize_logger(with_click_context):


### PR DESCRIPTION
## What?
There are 3 levels of verbosity now: `warning`, `info` and `debug`, which are triggered by using the `-v` or `-vv` flags.

## Why?
To help customers debug issues themselves easily.

## References
https://github.com/binbashar/leverage/issues/202

## Before release
If there is any workflow relying on the log outputs, it will have to be revisited.
