### PR TITLE
kubectl commands must be run from a layer too

### DIFF
--- a/leverage/containers/kubectl.py
+++ b/leverage/containers/kubectl.py
@@ -40,7 +40,7 @@ class KubeCtlContainer(TerraformContainer):
 
     def configure(self):
         # make sure we are on the cluster layer
-        self.check_for_layer_location()
+        self.check_for_cluster_layer()
 
         logger.info("Retrieving k8s cluster information...")
         # generate the command that will configure the new cluster
@@ -67,8 +67,8 @@ class KubeCtlContainer(TerraformContainer):
         aws_eks_cmd = next(op for op in output.split("\r\n") if op.startswith("aws eks update-kubeconfig"))
         return aws_eks_cmd + f" --region {self.region}"
 
-    def check_for_layer_location(self):
-        super(KubeCtlContainer, self).check_for_layer_location()
+    def check_for_cluster_layer(self):
+        self.check_for_layer_location()
         # assuming the "cluster" layer will contain the expected EKS outputs
         if self.cwd.parts[-1] != "cluster":
             logger.error("This command can only run at the [bold]cluster layer[/bold].")

--- a/leverage/modules/kubectl.py
+++ b/leverage/modules/kubectl.py
@@ -18,6 +18,7 @@ def kubectl(context, state, args):
     """Run Kubectl commands in a custom containerized environment."""
     state.container = KubeCtlContainer(get_docker_client())
     state.container.ensure_image()
+    state.container.check_for_layer_location()
     _handle_subcommand(context=context, cli_container=state.container, args=args)
 
 

--- a/tests/test_containers/test_kubectl.py
+++ b/tests/test_containers/test_kubectl.py
@@ -39,14 +39,14 @@ def test_get_eks_kube_config_tf_output_error(kubectl_container):
             kubectl_container._get_eks_kube_config()
 
 
-def test_check_for_layer_location(kubectl_container, propagate_logs, caplog):
+def test_check_for_cluster_layer(kubectl_container, propagate_logs, caplog):
     """
     Test that if we are not on a cluster layer, we raise an error.
     """
     with patch.object(TerraformContainer, "check_for_layer_location"):  # assume parent method is already tested
         with pytest.raises(Exit):
             kubectl_container.cwd = Path("/random")
-            kubectl_container.check_for_layer_location()
+            kubectl_container.check_for_cluster_layer()
 
     assert caplog.messages[0] == "This command can only run at the [bold]cluster layer[/bold]."
 
@@ -80,7 +80,7 @@ def test_start_shell(kubectl_container):
 
 
 # don't rely on the filesystem
-@patch.object(KubeCtlContainer, "check_for_layer_location", Mock())
+@patch.object(KubeCtlContainer, "check_for_cluster_layer", Mock())
 # nor terraform
 @patch.object(KubeCtlContainer, "_get_eks_kube_config", Mock(return_value=AWS_EKS_UPDATE_KUBECONFIG))
 def test_configure(kubectl_container, fake_os_user):


### PR DESCRIPTION
## What?
Force regular commands to be run on a layer, to avoid issues while refreshing aws credentials.

## Why?
For a better UX.

## References
Reported by @juanmatias while trying to run a `kc` command on a non-layer folder of a project.

## Before release
Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)
