### PR TITLE
refresh-credentials command

### DIFF
--- a/leverage/container.py
+++ b/leverage/container.py
@@ -661,6 +661,11 @@ class TerraformContainer(LeverageContainer):
             logger.error("This command can only run at [bold]layer[/bold] level.")
             raise Exit(1)
 
+    def refresh_credentials(self):
+        with AwsCredsEntryPoint(self, override_entrypoint=""):
+            if exit_code := self._start('echo "Done."'):
+                return exit_code
+
     def start(self, command, *arguments):
         with AwsCredsEntryPoint(self, self.entrypoint):
             return self._start(command, *arguments)

--- a/leverage/modules/terraform.py
+++ b/leverage/modules/terraform.py
@@ -187,6 +187,15 @@ def _import(tf, address, _id):
         raise Exit(exit_code)
 
 
+@terraform.command("refresh-credentials")
+@pass_container
+def refresh_credentials(tf):
+    """Refresh the AWS credentials used on the current layer."""
+    tf.check_for_layer_location()
+    if exit_code := tf.refresh_credentials():
+        raise Exit(exit_code)
+
+
 # ###########################################################################
 # HANDLER FOR MANAGING THE BASE COMMANDS (init, plan, apply, destroy, output)
 # ###########################################################################

--- a/tests/test_containers/__init__.py
+++ b/tests/test_containers/__init__.py
@@ -18,4 +18,5 @@ def container_fixture_factory(container_class):
     with patch("leverage.container.load_env", return_value=FAKE_ENV):
         container = container_class(mocked_client)
         container._run = Mock()
+        container._check_sso_token = Mock()
         return container

--- a/tests/test_containers/test_terraform.py
+++ b/tests/test_containers/test_terraform.py
@@ -24,3 +24,14 @@ def test_tf_plugin_cache_dir(terraform_container):
 
     # and the cache folder mounted
     assert next(m for m in container_args["host_config"]["Mounts"] if m["Target"] == "/home/testing/.terraform/cache")
+
+
+def test_refresh_credentials(terraform_container):
+    terraform_container.enable_sso()
+    terraform_container.refresh_credentials()
+    container_args = terraform_container.client.api.create_container.call_args_list[0][1]
+
+    # we want a shell, so -> /bin/bash with no entrypoint
+    assert container_args["command"] == 'echo "Done."'
+    # import ipdb; ipdb.set_trace()
+    assert container_args["entrypoint"] == "/root/scripts/aws-sso/aws-sso-entrypoint.sh -- "


### PR DESCRIPTION
## What?
Create a command dedicated to refresh the AWS credentials, relying on the `terraform` sso/mfa scripts

## Why?
To simplify the credentials renewal on any script

## Before release

Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)
