### PR TITLE
[BB-233] Rename generic to shell + fix terraform mount/env-var support

### DIFF
--- a/leverage/container.py
+++ b/leverage/container.py
@@ -516,20 +516,22 @@ class TerraformContainer(LeverageContainer):
         # SSH AGENT
         SSH_AUTH_SOCK = os.getenv("SSH_AUTH_SOCK")
 
-        self.environment = {
-            "COMMON_CONFIG_FILE": self.common_tfvars,
-            "ACCOUNT_CONFIG_FILE": self.account_tfvars,
-            "BACKEND_CONFIG_FILE": self.backend_tfvars,
-            "AWS_SHARED_CREDENTIALS_FILE": f"{self.guest_aws_credentials_dir}/credentials",
-            "AWS_CONFIG_FILE": f"{self.guest_aws_credentials_dir}/config",
-            "SRC_AWS_SHARED_CREDENTIALS_FILE": f"{self.guest_aws_credentials_dir}/credentials",  # Legacy?
-            "SRC_AWS_CONFIG_FILE": f"{self.guest_aws_credentials_dir}/config",  # Legacy?
-            "AWS_CACHE_DIR": f"{self.guest_aws_credentials_dir}/cache",
-            "SSO_CACHE_DIR": f"{self.guest_aws_credentials_dir}/sso/cache",
-            "SCRIPT_LOG_LEVEL": get_script_log_level(),
-            "MFA_SCRIPT_LOG_LEVEL": get_script_log_level(),  # Legacy
-            "SSH_AUTH_SOCK": "" if SSH_AUTH_SOCK is None else "/ssh-agent",
-        }
+        self.environment.update(
+            {
+                "COMMON_CONFIG_FILE": self.common_tfvars,
+                "ACCOUNT_CONFIG_FILE": self.account_tfvars,
+                "BACKEND_CONFIG_FILE": self.backend_tfvars,
+                "AWS_SHARED_CREDENTIALS_FILE": f"{self.guest_aws_credentials_dir}/credentials",
+                "AWS_CONFIG_FILE": f"{self.guest_aws_credentials_dir}/config",
+                "SRC_AWS_SHARED_CREDENTIALS_FILE": f"{self.guest_aws_credentials_dir}/credentials",  # Legacy?
+                "SRC_AWS_CONFIG_FILE": f"{self.guest_aws_credentials_dir}/config",  # Legacy?
+                "AWS_CACHE_DIR": f"{self.guest_aws_credentials_dir}/cache",
+                "SSO_CACHE_DIR": f"{self.guest_aws_credentials_dir}/sso/cache",
+                "SCRIPT_LOG_LEVEL": get_script_log_level(),
+                "MFA_SCRIPT_LOG_LEVEL": get_script_log_level(),  # Legacy
+                "SSH_AUTH_SOCK": "" if SSH_AUTH_SOCK is None else "/ssh-agent",
+            }
+        )
         self.entrypoint = self.TF_BINARY
         extra_mounts = [
             Mount(source=self.root_dir.as_posix(), target=self.guest_base_path, type="bind"),

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -8,7 +8,7 @@ from leverage.tasks import load_tasks
 from leverage.tasks import list_tasks as _list_tasks
 from leverage._internals import pass_state
 
-from leverage.modules import aws, run, project, terraform, credentials, tfautomv, kubectl, generic
+from leverage.modules import aws, run, project, terraform, credentials, tfautomv, kubectl, shell
 
 
 @click.group(invoke_without_command=True)
@@ -52,4 +52,4 @@ leverage.add_command(aws)
 leverage.add_command(tfautomv)
 leverage.add_command(kubectl)
 leverage.add_command(kubectl, name="kc")
-leverage.add_command(generic)
+leverage.add_command(shell)

--- a/leverage/modules/__init__.py
+++ b/leverage/modules/__init__.py
@@ -5,4 +5,4 @@ from .terraform import terraform
 from .credentials import credentials
 from .tfautomv import tfautomv
 from .kubectl import kubectl
-from .generic import generic
+from .shell import shell

--- a/leverage/modules/shell.py
+++ b/leverage/modules/shell.py
@@ -2,28 +2,29 @@ import click
 
 from leverage._utils import CustomEntryPoint
 from leverage.container import get_docker_client, TerraformContainer
+from leverage.modules.utils import env_var_option, mount_option, auth_sso, auth_mfa
 
 
 @click.command()
-@click.option("--mount", multiple=True, type=click.Tuple([str, str]))
-@click.option("--env-var", multiple=True, type=click.Tuple([str, str]))
-@click.option("--mfa", is_flag=True, default=False, help="Enable Multi Factor Authentication upon launching shell.")
-@click.option("--sso", is_flag=True, default=False, help="Enable SSO Authentication upon launching shell.")
-def generic(mount, env_var, mfa, sso):
+@mount_option
+@env_var_option
+@auth_mfa
+@auth_sso
+def shell(mount, env_var, mfa, sso):
     """
     Run a shell in a generic container. It supports mounting local paths and injecting arbitrary environment variables.
     It also supports AWS credentials injection via mfa/sso.
 
     Syntax:
-    leverage generic --mount <local-path> <container-path> --env-var <name> <value>
+    leverage shell --mount <local-path> <container-path> --env-var <name> <value>
 
     Example:
-    leverage generic --mount /home/user/bin/ /usr/bin/ --env-var env dev
+    leverage shell --mount /home/user/bin/ /usr/bin/ --env-var env dev
 
     Both mount and env-var parameters can be provided multiple times.
 
     Example:
-    leverage generic --mount /home/user/bin/ /usr/bin/ --mount /etc/config.ini /etc/config.ini --env-var init 5 --env-var env dev
+    leverage shell --mount /home/user/bin/ /usr/bin/ --mount /etc/config.ini /etc/config.ini --env-var init 5 --env-var env dev
     """
     if env_var:
         env_var = dict(env_var)

--- a/leverage/modules/utils.py
+++ b/leverage/modules/utils.py
@@ -1,3 +1,4 @@
+import click
 from click.exceptions import Exit
 
 
@@ -32,3 +33,11 @@ def _handle_subcommand(context, cli_container, args, caller_name=None):
             context.invoke(subcommand)
         else:
             context.forward(subcommand)
+
+
+mount_option = click.option("--mount", multiple=True, type=click.Tuple([str, str]))
+env_var_option = click.option("--env-var", multiple=True, type=click.Tuple([str, str]))
+auth_mfa = click.option(
+    "--mfa", is_flag=True, default=False, help="Enable Multi Factor Authentication upon launching shell."
+)
+auth_sso = click.option("--sso", is_flag=True, default=False, help="Enable SSO Authentication upon launching shell.")


### PR DESCRIPTION
## What?
Rename `generic` command to `shell` for better association.
Fix mount/env-vars support on the `terraform` commands.

## References
#233 
