### PR TITLE
fix: 'AWSCLIContainer' object has no attribute 'common_conf

### DIFF
--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -312,7 +312,7 @@ def _load_configs_for_credentials():
 
     terraform_config = {}
     logger.info("Loading Terraform common configuration.")
-    terraform_config = AWSCLI.common_conf
+    terraform_config = AWSCLI.paths.common_conf
 
     config_values = {}
     config_values["short_name"] = (


### PR DESCRIPTION
Problem has been explained in the issue [HERE](https://github.com/binbashar/leverage/issues/242).

## What?
* It is a small fix after recently merged [PR](https://github.com/binbashar/leverage/pull/232).

## Why?
* CLI breaks on running `leverage credentials configure --type BOOTSTRAP`

## References
* https://github.com/binbashar/leverage/issues/242

## Before release

Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)
