### PR TITLE
Add Version Compatibility section to release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,7 +36,7 @@ version-resolver:
       - 'patch'
   default: patch
 footer: |
-  REMINDER: please remember to add a Version Compatibility section before publishing a release draft.
+  *REMINDER:* please remember to add or update the Version Compatibility section before publishing a release draft.
 template: |
   ## Changes
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,8 +36,7 @@ version-resolver:
       - 'patch'
   default: patch
 footer: |
-  * Version Compatibility
-    * TODO
+  REMINDER: please remember to add a Version Compatibility section before publishing a release draft.
 template: |
   ## Changes
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,9 +22,6 @@ categories:
     label:
       - 'chore'
       - 'maintenance'
-  - title: 'Version Compatibility'
-    label:
-      - 'unknown'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
@@ -38,6 +35,9 @@ version-resolver:
     labels:
       - 'patch'
   default: patch
+footer: |
+  * Version Compatibility
+    * TODO
 template: |
   ## Changes
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,6 +22,9 @@ categories:
     label:
       - 'chore'
       - 'maintenance'
+  - title: 'Version Compatibility'
+    label:
+      - 'unknown'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:


### PR DESCRIPTION
## What?
* Add Version Compatibility section as a footer of the release.

## Why?
* We decided to add such section so that Leverage users can know which Docker Toolbox Image they can use with every release.

## References
* #158 

## Before release

Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)
