### PR TITLE
[BB-235] project short name validation

### DIFF
--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -290,10 +290,10 @@ def validate_config(config: dict):
             "Project name is not valid. Only lowercase alphanumeric characters and hyphens are allowed. It must be 25 characters long at most.",
         )
 
-    if not re.match(r"^[a-z0-9]{2,4}$", config["short_name"]):
+    if not re.match(r"^[a-z]{2,4}$", config["short_name"]):
         raise ExitError(
             1,
-            "Project short name is not valid. Only lowercase alphanumeric characters are allowed. It must be between 2 and 4 characters long.",
+            "Project short name is not valid. Only lowercase alphabetic characters are allowed. It must be between 2 and 4 characters long.",
         )
 
     return True

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -290,6 +290,12 @@ def validate_config(config: dict):
             "Project name is not valid. Only lowercase alphanumeric characters and hyphens are allowed. It must be 25 characters long at most.",
         )
 
+    if not re.match(r"^[a-z0-9]{2,4}$", config["short_name"]):
+        raise ExitError(
+            1,
+            "Project short name is not valid. Only lowercase alphanumeric characters are allowed. It must be between 2 and 4 characters long.",
+        )
+
     return True
 
 

--- a/tests/test_modules/test_project.py
+++ b/tests/test_modules/test_project.py
@@ -39,10 +39,11 @@ def test_validate_config_project_name_errors(muted_click_context, invalid_name):
 @pytest.mark.parametrize(
     "invalid_name",
     [
-        "longerthan4",
+        "longerthan",
         "1",
         "@-!#",
         "",
+        "UPPR",
     ],
 )
 def test_validate_config_short_project_name_errors(muted_click_context, invalid_name):

--- a/tests/test_modules/test_project.py
+++ b/tests/test_modules/test_project.py
@@ -14,8 +14,7 @@ from leverage.modules.project import validate_config
         ("hyphens-are-allowed", "ok"),
         # different valid short project names
         ("fine", "foo"),
-        ("fine", "123"),
-        ("fine", "max3"),
+        ("fine", "full"),
     ],
 )
 def test_validate_config_happy_path(project_name, short_name):

--- a/tests/test_modules/test_project.py
+++ b/tests/test_modules/test_project.py
@@ -4,22 +4,47 @@ from leverage._utils import ExitError
 from leverage.modules.project import validate_config
 
 
-def test_validate_config_happy_path():
-    assert validate_config({"project_name": "fine"})
-    assert validate_config({"project_name": "fine123"})
-    assert validate_config({"project_name": "123fine"})
-    assert validate_config({"project_name": "hyphens-are-allowed"})
+@pytest.mark.parametrize(
+    "project_name,short_name",
+    [
+        # different valid project names
+        ("fine", "ok"),
+        ("fine123", "ok"),
+        ("123fine", "ok"),
+        ("hyphens-are-allowed", "ok"),
+        # different valid short project names
+        ("fine", "foo"),
+        ("fine", "123"),
+        ("fine", "max3"),
+    ],
+)
+def test_validate_config_happy_path(project_name, short_name):
+    assert validate_config({"project_name": project_name, "short_name": short_name})
 
 
-def test_validate_config_errors(muted_click_context):
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "with spaces",
+        "underscores_not_allowed",
+        "not-alph@-characters!",
+        "loooooooooooooooooooooooooooooooooooooooooooooooooooooong",
+    ],
+)
+def test_validate_config_project_name_errors(muted_click_context, invalid_name):
     with pytest.raises(ExitError, match="Project name is not valid"):
-        validate_config({"project_name": "with spaces"})
+        validate_config({"project_name": invalid_name, "short_name": "ok"})
 
-    with pytest.raises(ExitError, match="Project name is not valid"):
-        validate_config({"project_name": "underscores_not_allowed"})
 
-    with pytest.raises(ExitError, match="Project name is not valid"):
-        validate_config({"project_name": "not-alph@-characters!"})
-
-    with pytest.raises(ExitError, match="Project name is not valid"):
-        validate_config({"project_name": "loooooooooooooooooooooooooooooooooooooooooooooooooooooong"})
+@pytest.mark.parametrize(
+    "invalid_name",
+    [
+        "longerthan4",
+        "1",
+        "@-!#",
+        "",
+    ],
+)
+def test_validate_config_short_project_name_errors(muted_click_context, invalid_name):
+    with pytest.raises(ExitError, match="Project short name is not valid"):
+        validate_config({"project_name": "test", "short_name": invalid_name})


### PR DESCRIPTION
## What?
Validate the short project name length at project creation time.

## Why?
Otherwise it breaks the flow, no the credential generation steps.

## References
closes #235

https://github.com/binbashar/le-tf-infra-aws-template/blob/ab1f86db606f24581825910b969a456bc408aa6a/le-resources/project.yaml#L2
