### PR TITLE
[229] Fix issue with --version option

### DIFF
--- a/leverage/modules/credentials.py
+++ b/leverage/modules/credentials.py
@@ -1,28 +1,27 @@
 """
     Credentials managing module.
 """
-import re
 import csv
 import json
-from pathlib import Path
+import re
 from functools import wraps
+from pathlib import Path
 
 import click
-from click.exceptions import Exit
 import questionary
+from click.exceptions import Exit
 from questionary import Choice
 from ruamel.yaml import YAML
 
 from leverage import __toolbox_version__
 from leverage import logger
-from leverage._utils import ExitError
-from leverage.path import get_root_path
-from leverage.path import get_global_config_path
-from leverage.path import NotARepositoryError
 from leverage._internals import pass_state
-from leverage.container import get_docker_client
+from leverage._utils import ExitError
 from leverage.container import AWSCLIContainer
-
+from leverage.container import get_docker_client
+from leverage.path import NotARepositoryError
+from leverage.path import get_global_config_path
+from leverage.path import get_project_root_or_current_dir_path
 
 # Regexes for general validation
 PROJECT_SHORT = r"[a-z]{2,4}"
@@ -38,11 +37,11 @@ ACCOUNT_ID = r"[0-9]{12}"
 MFA_SERIAL = rf"arn:aws:iam::{ACCOUNT_ID}:mfa/{USERNAME}"
 
 # TODO: Remove these and get them into the global app state
+PROJECT_ROOT = get_project_root_or_current_dir_path()
 try:
     PROJECT_COMMON_TFVARS = Path(get_global_config_path())
-    PROJECT_ROOT = Path(get_root_path())
 except NotARepositoryError:
-    PROJECT_COMMON_TFVARS = PROJECT_ROOT = Path.cwd()
+    PROJECT_COMMON_TFVARS = Path.cwd()
 
 PROJECT_COMMON_TFVARS_FILE = "common.tfvars"
 PROJECT_COMMON_TFVARS = PROJECT_COMMON_TFVARS / PROJECT_COMMON_TFVARS_FILE

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -16,7 +16,7 @@ from jinja2 import FileSystemLoader
 from leverage import __toolbox_version__
 from leverage import logger
 from leverage.logger import console
-from leverage.path import get_root_path
+from leverage.path import get_root_path, get_project_root_or_current_dir_path
 from leverage.path import NotARepositoryError
 from leverage._utils import git, ExitError
 from leverage.container import get_docker_client
@@ -33,10 +33,7 @@ LEVERAGE_TEMPLATE_REPO = "https://github.com/binbashar/le-tf-infra-aws-template.
 IGNORE_PATTERNS = ignore_patterns(TEMPLATE_PATTERN, ".gitkeep")
 
 # Useful project related definitions
-try:
-    PROJECT_ROOT = Path(get_root_path())
-except NotARepositoryError:
-    PROJECT_ROOT = Path.cwd()
+PROJECT_ROOT = get_project_root_or_current_dir_path()
 PROJECT_CONFIG = PROJECT_ROOT / PROJECT_CONFIG_FILE
 
 CONFIG_DIRECTORY = "config"

--- a/leverage/path.py
+++ b/leverage/path.py
@@ -3,9 +3,9 @@
 """
 import os
 from pathlib import Path
-from subprocess import run
-from subprocess import PIPE
 from subprocess import CalledProcessError
+from subprocess import PIPE
+from subprocess import run
 
 import hcl2
 
@@ -13,7 +13,7 @@ from leverage._utils import ExitError
 
 
 class NotARepositoryError(RuntimeError):
-    pass
+    """When you are not running inside a git repository directory"""
 
 
 def get_working_path():
@@ -51,8 +51,10 @@ def get_root_path():
     except CalledProcessError as exc:
         if "fatal: not a git repository" in exc.stderr:
             raise NotARepositoryError("Not running in a git repository.")
-
-    return root.strip()
+    except FileNotFoundError as exc:
+        raise NotARepositoryError("Not running in a git repository.")
+    else:
+        return root.strip()
 
 
 def get_account_path():
@@ -274,3 +276,13 @@ class PathsHandler:
         # assuming the "cluster" layer will contain the expected EKS outputs
         if self.cwd.parts[-1] != "cluster":
             raise ExitError(1, "This command can only run at the [bold]cluster layer[/bold].")
+
+
+def get_project_root_or_current_dir_path() -> Path:
+    """Returns the project root if detected, otherwise the current path"""
+    try:
+        root = Path(get_root_path())
+    except (NotARepositoryError, TypeError):
+        root = Path.cwd()
+
+    return root

--- a/tests/test_root_path.py
+++ b/tests/test_root_path.py
@@ -1,0 +1,68 @@
+from subprocess import CalledProcessError
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from leverage.path import get_root_path, NotARepositoryError
+
+
+class TestGetRootPath:
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        """Setup common test resources and mock patches."""
+        self.mock_run_patcher = patch("leverage.path.run")
+        self.mock_run = self.mock_run_patcher.start()
+        yield
+        self.mock_run_patcher.stop()
+
+    def test_in_valid_git_repository(self):
+        """Test get_root_path returns the correct path in a valid Git repository."""
+        self.mock_run.return_value = MagicMock(stdout="path/to/repo\n")
+        assert get_root_path() == "path/to/repo"
+
+    def test_outside_of_git_repository(self):
+        """Test get_root_path raises NotARepositoryError when outside a Git repository."""
+        self.mock_run.side_effect = CalledProcessError(
+            returncode=1, cmd=["git", "rev-parse", "--show-toplevel"], stderr="fatal: not a git repository"
+        )
+        with pytest.raises(NotARepositoryError):
+            get_root_path()
+
+    def test_with_git_not_installed(self):
+        """Test get_root_path raises NotARepositoryError if git is not installed (FileNotFoundError)."""
+        self.mock_run.side_effect = FileNotFoundError()
+        with pytest.raises(NotARepositoryError):
+            get_root_path()
+
+    def test_in_a_git_submodule(self):
+        """
+        Test get_root_path correctly identifies the root of the main Git repository when called from within a submodule.
+        """
+        # Assuming submodules will have a different path structure
+        self.mock_run.return_value = MagicMock(stdout="path/to/main/repo\n")
+        assert get_root_path() == "path/to/main/repo"
+
+    def test_in_newly_initialized_git_repo_without_commits(self):
+        """Test get_root_path in a new Git repo that has no commits yet."""
+        # In practice, this should succeed as the command works in empty repos as well
+        self.mock_run.return_value = MagicMock(stdout="path/to/new/repo\n")
+        assert get_root_path() == "path/to/new/repo"
+
+    def test_with_permissions_issue_on_git_directory(self):
+        """Test get_root_path behavior when there's a permissions issue on the .git directory."""
+        self.mock_run.side_effect = PermissionError()
+        with pytest.raises(PermissionError):
+            get_root_path()
+
+    def test_with_large_output_from_git_rev_parse(self):
+        """Test get_root_path correctly handles and processes large outputs from the git rev-parse command."""
+        # Simulating a large output scenario
+        large_path = "path/to/repo" * 1000 + "\n"
+        self.mock_run.return_value = MagicMock(stdout=large_path)
+        assert get_root_path() == large_path.strip()
+
+    def test_in_git_repo_with_unusual_characters_in_path(self):
+        """Test get_root_path handles paths with spaces, special, or non-ASCII characters."""
+        unusual_path = "path/to/🚀 project with spaces\n"
+        self.mock_run.return_value = MagicMock(stdout=unusual_path)
+        assert get_root_path() == unusual_path.strip()


### PR DESCRIPTION
## What?
* When trying to access the `root` variable and and exception happened, root cannot be accessed because it does not exist.
* We have to use else there so we only try to access `root` when there is no exception happening.
* New get_project_root_or_current_dir_path method to get the root of the project path. 

## Why?
* To avoid issues when running  `leverage --version`. Otherwise the command would just exit with an unhandled exception like it is described in the issue.

## References
* Use `closes #229`

## Before release

Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)
