### PR TITLE
[SSO Login] Remove now unnecessary restrictions

### DIFF
--- a/leverage/modules/aws.py
+++ b/leverage/modules/aws.py
@@ -202,15 +202,6 @@ def sso(context, cli, args):
 @pass_container
 def login(cli):
     """Login"""
-    # only from account or layer directories
-    # when to fail:
-    # - when this cond meets:
-    #   - no account dir
-    #   - no layer dir
-    if not cli.paths.get_location_type() in ["account", "layer", "layers-group"]:
-        logger.error("SSO configuration can only be performed at [bold]layer[/bold] or [bold]account[/bold] level.")
-        raise Exit(1)
-
     exit_code, region = cli.exec(f"configure get sso_region --profile {cli.project}-sso")
     if exit_code:
         logger.error(f"Region configuration for [bold]{cli.project}-sso[/bold] profile not found.")


### PR DESCRIPTION
## What?
Given the changes introduced in the SSO role management, these restrictions are not required anymore.