### PR TITLE
[159] Improve apply arguments parsing logic

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -26,6 +26,7 @@ jobs:
       max-parallel: 1
       matrix:
         python-version: [3.8.14,3.9.15,3.10.8]
+        toolbox-image-tag: ['1.3.5-0.1.15', '1.5.0-0.1.15', '1.6.0-0.1.15']
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v3
@@ -153,6 +154,12 @@ jobs:
           printf "[INFO] Cloning repo...\n"
           git clone https://github.com/binbashar/le-tf-infra-aws.git ../theblairwitchproject
 
+      - name: Set Toolbox Image Tag for the cloned ref arch repo
+        run: |
+          echo "Updating Terraform Image Tag to ${{ matrix.toolbox-image-tag }}"
+          sed -E -i 's/^TERRAFORM_IMAGE_TAG=.+$/TERRAFORM_IMAGE_TAG=${{ matrix.toolbox-image-tag }}/' build.env
+        working-directory: ../theblairwitchproject
+
       - name: Configure Testing Reference Architecture
         run: |
           echo "[INFO] Configure Reference Architecture\n"
@@ -175,7 +182,6 @@ jobs:
           EOF
           echo "[INFO] Disable MFA\n"
           sed -i "s/^\(MFA_ENABLED=\)true/\1false/" build.env
-          sed -E -i 's/^TERRAFORM_IMAGE_TAG=.+$/TERRAFORM_IMAGE_TAG=1.2.7-0.0.5/' build.env;
         working-directory: ../theblairwitchproject
 
       - name: Test Testing Reference Architecture

--- a/tests/test_modules/terraform/test_handle_apply_arguments_parsing.py
+++ b/tests/test_modules/terraform/test_handle_apply_arguments_parsing.py
@@ -1,0 +1,35 @@
+import pytest
+
+from leverage.modules.terraform import handle_apply_arguments_parsing
+
+
+class TestHandleApplyArgumentsParsing:
+    @pytest.mark.parametrize(
+        "input_args,expected_output",
+        [
+            # Test case: Single '-key=value'
+            (["-target=kubernetes_manifest.irfq"], ["-target=kubernetes_manifest.irfq"]),
+            # Test case: '-key value'
+            (["-target", "kubernetes_manifest.irfq"], ["-target", "kubernetes_manifest.irfq"]),
+            # Test case: Multiple mixed arguments
+            (
+                ["-target", "kubernetes_manifest.irfq", "-lock=false"],
+                ["-target", "kubernetes_manifest.irfq", "-lock=false"],
+            ),
+            # Test case: '-var' arguments should be included as is
+            (["-var", "name=value"], ["-var", "name=value"]),
+            # Test case: Non-flag argument
+            (["some_value"], ["some_value"]),
+            # Test case: Mixed '-key=value' and '-key value' with '-var'
+            (
+                ["-var", "name=value", "-target", "kubernetes_manifest.irfq", "-lock=false"],
+                ["-var", "name=value", "-target", "kubernetes_manifest.irfq", "-lock=false"],
+            ),
+            # Test case: No arguments
+            ([], []),
+            # Test case: '-key=value' format with '-var'
+            (["-var", "name=value", "-lock=false"], ["-var", "name=value", "-lock=false"]),
+        ],
+    )
+    def test_handle_apply_arguments_parsing(self, input_args, expected_output):
+        assert handle_apply_arguments_parsing(input_args) == expected_output


### PR DESCRIPTION
## What?
* Current logic for parsing arguments after `apply` does not work as expected.
* `leverage tf apply -target kubernetes_manifest.irfq` -> fails
* `leverage tf apply -target kubernetes_manifest.irfq` -> works

## Why?
* both options for specifying parameters with space or equal should work.

## References
* https://github.com/binbashar/leverage/issues/159
* `closes #159`

## Before release

Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)
