### PR TITLE
Pin requests to 2.31

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1738,4 +1738,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.8 || ~3.9 || ~3.10 || ~3.11"
-content-hash = "b69fa29e920622bef134696a595d53d1ec212fbe3ea42765d58c13b3266720e2"
+content-hash = "5d56ff348ace7187971f87c7052f0709eb4bcd4730a3986fffec2d10cd0b4f3a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ configupdater = "3.2"
 docutils = "0.17.1"
 rich = "10.4.0"
 
+requests = "2.31"
 [tool.poetry.group.dev.dependencies]
 pylint = "2.8.3"
 pytest = "6.2.4"


### PR DESCRIPTION
## Why?
We are facing this issue in some of our CI tests: https://github.com/docker/docker-py/issues/3256
And it is probably affecting people already.

The issue is fixed in docker-py [7.1.0](https://github.com/docker/docker-py/releases/tag/7.1.0) but that would mean a major upgrade in our core library.

Let's go for the quick fix by now