### PR TITLE
Bugfix | Catch error for not found/forbidden role

### DIFF
--- a/leverage/modules/auth.py
+++ b/leverage/modules/auth.py
@@ -125,7 +125,7 @@ def refresh_layer_credentials(cli):
                 accessToken=cli.get_sso_access_token(),
             )["roleCredentials"]
         except ClientError as error:
-            if error.response["Error"]["Code"] == "ForbiddenException":
+            if error.response["Error"]["Code"] in ("AccessDeniedException", "ForbiddenException"):
                 raise ExitError(
                     40,
                     f"User does not have permission to assume role [bold]{sso_role}[/bold]"

--- a/leverage/modules/auth.py
+++ b/leverage/modules/auth.py
@@ -1,10 +1,11 @@
 import time
-from configparser import NoSectionError, NoOptionError
 from pathlib import Path
+from configparser import NoSectionError, NoOptionError
 
-import boto3
 import hcl2
+import boto3
 from configupdater import ConfigUpdater
+from botocore.exceptions import ClientError
 
 from leverage import logger
 from leverage._utils import key_finder, ExitError, get_or_create_section
@@ -40,7 +41,7 @@ def get_layer_profile(raw_profile: str, config_updater: ConfigUpdater, tf_profil
     except NoSectionError:
         raise ExitError(40, f"Missing {sso_profile} permission for account {account_name}.")
 
-    # if we are processing a profile from a different layer, we need to built it
+    # if we are processing a profile from a different layer, we need to build it
     layer_profile = layer_profile or f"{project}-{account_name}-{sso_role.lower()}"
 
     return account_id, account_name, sso_role, layer_profile
@@ -104,7 +105,7 @@ def refresh_layer_credentials(cli):
             expiration = int(config_updater.get(f"profile {layer_profile}", "expiration").value) / 1000
         except (NoSectionError, NoOptionError):
             # first time using this profile, skip into the credential's retrieval step
-            logger.debug(f"No cached credentials found.")
+            logger.debug("No cached credentials found.")
         else:
             # we reduce the validity 30 minutes, to avoid expiration over long-standing tasks
             renewal = time.time() + (30 * 60)
@@ -117,11 +118,20 @@ def refresh_layer_credentials(cli):
 
         # retrieve credentials
         logger.debug(f"Retrieving role credentials for {sso_role}...")
-        credentials = client.get_role_credentials(
-            roleName=sso_role,
-            accountId=account_id,
-            accessToken=cli.get_sso_access_token(),
-        )["roleCredentials"]
+        try:
+            credentials = client.get_role_credentials(
+                roleName=sso_role,
+                accountId=account_id,
+                accessToken=cli.get_sso_access_token(),
+            )["roleCredentials"]
+        except ClientError as error:
+            if error.response["Error"]["Code"] == "ForbiddenException":
+                raise ExitError(
+                    40,
+                    f"User does not have permission to assume role [bold]{sso_role}[/bold]"
+                    " in this account.\nPlease check with your administrator or try"
+                    " running [bold]leverage aws configure sso[/bold].",
+                )
 
         # update expiration on aws/<project>/config
         logger.info(f"Writing {layer_profile} profile")

--- a/tests/test_modules/test_auth.py
+++ b/tests/test_modules/test_auth.py
@@ -277,7 +277,7 @@ def test_refresh_layer_credentials(mock_boto, mock_open, mock_update_conf, sso_c
     [
         ClientError({"Error": {"Code": "AccessDeniedException", "Message": "No access"}}, "GetRoleCredentials"),
         ClientError({"Error": {"Code": "ForbiddenException", "Message": "No access"}}, "GetRoleCredentials"),
-    ]
+    ],
 )
 def test_refresh_layer_credentials_no_access(mock_update_conf, mock_open, sso_container, error):
     with mock.patch("boto3.client") as mocked_client:

--- a/tests/test_modules/test_auth.py
+++ b/tests/test_modules/test_auth.py
@@ -251,6 +251,7 @@ def test_refresh_layer_credentials_still_valid(mock_open, mock_boto, sso_contain
 @mock.patch("leverage.modules.auth.update_config_section")
 @mock.patch("builtins.open", side_effect=open_side_effect)
 @mock.patch("time.time", new=Mock(return_value=1705859000))
+@mock.patch("boto3.client", return_value=b3_client)
 @mock.patch("pathlib.Path.touch", new=Mock())
 def test_refresh_layer_credentials(mock_boto, mock_open, mock_update_conf, sso_container, propagate_logs):
     refresh_layer_credentials(sso_container)

--- a/tests/test_modules/test_auth.py
+++ b/tests/test_modules/test_auth.py
@@ -279,7 +279,7 @@ def test_refresh_layer_credentials(mock_boto, mock_open, mock_update_conf, sso_c
         ClientError({"Error": {"Code": "ForbiddenException", "Message": "No access"}}, "GetRoleCredentials"),
     ]
 )
-def test_refresh_layer_credentials_no_access(mock_open, mock_update_conf, sso_container, error):
+def test_refresh_layer_credentials_no_access(mock_update_conf, mock_open, sso_container, error):
     with mock.patch("boto3.client") as mocked_client:
         mocked_client_obj = MagicMock()
         mocked_client_obj.get_role_credentials.side_effect = error

--- a/tests/test_modules/test_auth.py
+++ b/tests/test_modules/test_auth.py
@@ -250,7 +250,6 @@ def test_refresh_layer_credentials_still_valid(mock_open, mock_boto, sso_contain
 
 @mock.patch("leverage.modules.auth.update_config_section")
 @mock.patch("builtins.open", side_effect=open_side_effect)
-@mock.patch("boto3.client", return_value=b3_client)
 @mock.patch("time.time", new=Mock(return_value=1705859000))
 @mock.patch("pathlib.Path.touch", new=Mock())
 def test_refresh_layer_credentials(mock_boto, mock_open, mock_update_conf, sso_container, propagate_logs):
@@ -268,17 +267,22 @@ def test_refresh_layer_credentials(mock_boto, mock_open, mock_update_conf, sso_c
     }
 
 
-b3_client_error = Mock()
-b3_client_error.get_role_credentials.side_effect = ClientError(
-    {"Error": {"Code": "ForbiddenException", "Message": "No access"}}, "GetRoleCredentials"
-)
-
-
 @mock.patch("leverage.modules.auth.update_config_section")
 @mock.patch("builtins.open", side_effect=open_side_effect)
-@mock.patch("boto3.client", return_value=b3_client_error)
 @mock.patch("time.time", new=Mock(return_value=1705859000))
 @mock.patch("pathlib.Path.touch", new=Mock())
-def test_refresh_layer_credentials_no_access(mock_boto, mock_open, mock_update_conf, sso_container, propagate_logs):
-    with pytest.raises(ExitError):
-        refresh_layer_credentials(sso_container)
+@pytest.mark.parametrize(
+    "error",
+    [
+        ClientError({"Error": {"Code": "AccessDeniedException", "Message": "No access"}}, "GetRoleCredentials"),
+        ClientError({"Error": {"Code": "ForbiddenException", "Message": "No access"}}, "GetRoleCredentials"),
+    ]
+)
+def test_refresh_layer_credentials_no_access(mock_open, mock_update_conf, sso_container, error):
+    with mock.patch("boto3.client") as mocked_client:
+        mocked_client_obj = MagicMock()
+        mocked_client_obj.get_role_credentials.side_effect = error
+        mocked_client.return_value = mocked_client_obj
+
+        with pytest.raises(ExitError):
+            refresh_layer_credentials(sso_container)


### PR DESCRIPTION
## What?
* Catch exception and show a nice message when the configuration makes Leverage attempt to assume a role that either does not exist or the user does not have permission to assume.

## References
* Closes #262 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved error handling for AWS SSO credentials, providing users with detailed messages on permission issues.
	- Enhanced logging for better clarity during credential retrieval processes.

- **Bug Fixes**
	- Added tests to validate behavior when access to AWS credentials is denied, ensuring proper error handling.

- **Tests**
	- Introduced new test scenarios for AWS SSO profile management and credential refreshing, enhancing overall test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->