### PR TITLE
[BV-267] Make sure .gitconfig is always present

### DIFF
--- a/.github/workflows/tests-integration.yaml
+++ b/.github/workflows/tests-integration.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           mkdir -p ../theadamproject
           # These are later mounted in the container
-          mkdir ~/.ssh && touch ~/.gitconfig
+          mkdir ~/.ssh
 
       - name: Project Init
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN git clone https://github.com/bats-core/bats-assert.git
 
 # Needed as is mounted later on
 RUN mkdir /root/.ssh
-# Needed for git to run propertly
-RUN touch /root/.gitconfig
 
 RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local POETRY_VERSION=1.8.2 python3 -
 

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -455,6 +455,9 @@ class TerraformContainer(SSOContainer):
         # SSH AGENT
         SSH_AUTH_SOCK = os.getenv("SSH_AUTH_SOCK")
 
+        # make sure .gitconfig exists before mounting it
+        self.paths.host_git_config_file.touch(exist_ok=True)
+
         self.environment.update(
             {
                 "COMMON_CONFIG_FILE": self.paths.common_tfvars,
@@ -479,7 +482,7 @@ class TerraformContainer(SSOContainer):
                 target=self.paths.guest_aws_credentials_dir,
                 type="bind",
             ),
-            Mount(source=(self.paths.home / ".gitconfig").as_posix(), target="/etc/gitconfig", type="bind"),
+            Mount(source=self.paths.host_git_config_file.as_posix(), target="/etc/gitconfig", type="bind"),
         ]
         self.mounts.extend(extra_mounts)
         # if you have set the tf plugin cache locally

--- a/leverage/path.py
+++ b/leverage/path.py
@@ -198,6 +198,10 @@ class PathsHandler:
         return self.host_aws_credentials_dir / "credentials"
 
     @property
+    def host_git_config_file(self):
+        return self.home / ".gitconfig"
+
+    @property
     def local_backend_tfvars(self):
         return self.account_config_dir / self.BACKEND_TF_VARS
 

--- a/tests/bats/leverage.bats
+++ b/tests/bats/leverage.bats
@@ -35,7 +35,7 @@ teardown(){
     cp "$BUILD_SCRIPTS/simple_build.py" "$ACC_DIR/build.py"
     cd "$ACC_DIR"
 
-    run leverage -l
+    run leverage run -l
 
     assert_line --index 0 "Tasks in build file \`build.py\`:"
     assert_line --index 1 --regexp "^  hello\s+Say hello.$"
@@ -49,7 +49,7 @@ teardown(){
     cp "$BUILD_SCRIPTS/simple_build.py" "$ROOT_DIR/build.py"
     cd "$ROOT_DIR/account"
 
-    run leverage -l
+    run leverage run -l
 
     assert_line --index 0 "Tasks in build file \`build.py\`:"
     assert_line --index 1 --regexp "^  hello\s+Say hello.$"


### PR DESCRIPTION
## What?
Make sure there is always a .gitconfig file present in the home directory.

## Why?
So git can work properly inside the container.

## References
`closes #267`