### PR TITLE
BL-276 | Copy symlinks for common-variables.tf

### DIFF
--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -136,7 +136,7 @@ def _copy_account(account, primary_region):
             src=TEMPLATE_DIR / account / "global" / layer,
             dst=PROJECT_ROOT / account / "global" / layer,
             ignore=IGNORE_PATTERNS,
-            symlinks=True
+            symlinks=True,
         )
     # Copy all layers with a region in account
     for layer in PROJECT_STRUCTURE[account]["primary_region"]:
@@ -144,7 +144,7 @@ def _copy_account(account, primary_region):
             src=TEMPLATE_DIR / account / "primary_region" / layer,
             dst=PROJECT_ROOT / account / primary_region / layer,
             ignore=IGNORE_PATTERNS,
-            symlinks=True
+            symlinks=True,
         )
 
 

--- a/leverage/modules/project.py
+++ b/leverage/modules/project.py
@@ -136,6 +136,7 @@ def _copy_account(account, primary_region):
             src=TEMPLATE_DIR / account / "global" / layer,
             dst=PROJECT_ROOT / account / "global" / layer,
             ignore=IGNORE_PATTERNS,
+            symlinks=True
         )
     # Copy all layers with a region in account
     for layer in PROJECT_STRUCTURE[account]["primary_region"]:
@@ -143,6 +144,7 @@ def _copy_account(account, primary_region):
             src=TEMPLATE_DIR / account / "primary_region" / layer,
             dst=PROJECT_ROOT / account / primary_region / layer,
             ignore=IGNORE_PATTERNS,
+            symlinks=True
         )
 
 


### PR DESCRIPTION
## What?
Rather than copying the content of the common-variables.tf file, create a symlink pointing to the source file.

## Why?
To avoid unnecessary repetition of files

## References
`closes #276`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the directory copying process to preserve symbolic links. This ensures that the original structure and file relationships are maintained during the copying of project templates across various layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->