### PR TITLE
BL-143 | Version warning

### DIFF
--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -7,7 +7,10 @@
 __version__ = "0.0.0"
 __toolbox_version__ = "1.3.5-0.2.0"
 
-MINIMUM_VERSIONS = {"TERRAFORM": "1.3.5", "LEVERAGE_CLI": "0.2.0"}
+MINIMUM_VERSIONS = {
+    "TERRAFORM": "1.3.5",
+    "TOOLBOX": "0.2.0",
+}
 
 import sys
 from shutil import which

--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -7,6 +7,11 @@
 __version__ = "0.0.0"
 __toolbox_version__ = "1.3.5-0.2.0"
 
+MINIMUM_VERSIONS = {
+    "TERRAFORM": "1.3.5",
+    "LEVERAGE_CLI": "0.2.0"
+}
+
 import sys
 from shutil import which
 

--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -7,10 +7,7 @@
 __version__ = "0.0.0"
 __toolbox_version__ = "1.3.5-0.2.0"
 
-MINIMUM_VERSIONS = {
-    "TERRAFORM": "1.3.5",
-    "LEVERAGE_CLI": "0.2.0"
-}
+MINIMUM_VERSIONS = {"TERRAFORM": "1.3.5", "LEVERAGE_CLI": "0.2.0"}
 
 import sys
 from shutil import which

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -1,6 +1,7 @@
 """
     Binbash Leverage Command-line tool.
 """
+
 import rich
 from packaging.version import Version
 

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -39,7 +39,7 @@ def leverage(context, state, verbose):
     if not (current_values := config.get("TERRAFORM_IMAGE_TAG")):
         # at some points of the project (the init), the config file is not created yet
         return
-    # validate both CLI and TF versions
+    # validate both TOOLBOX and TF versions
     for key, current in zip(MINIMUM_VERSIONS, current_values.split("-")):
         if Version(current) < Version(MINIMUM_VERSIONS[key]):
             rich.print(

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -36,8 +36,11 @@ def leverage(context, state, verbose):
         return
 
     # check if the current versions are lower than the minimum required
-    current_values = config.get("TERRAFORM_IMAGE_TAG").split("-")
-    for key, current in zip(MINIMUM_VERSIONS, current_values):
+    if not (current_values := config.get("TERRAFORM_IMAGE_TAG")):
+        # at some points of the project (the init), the config file is not created yet
+        return
+    # validate both CLI and TF versions
+    for key, current in zip(MINIMUM_VERSIONS, current_values.split("-")):
         if Version(current) < Version(MINIMUM_VERSIONS[key]):
             rich.print(
                 f"[red]WARNING[/red]\tYour current {key} version ({current}) is lower than the required minimum ({MINIMUM_VERSIONS[key]})."

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -1,6 +1,7 @@
 """
     Binbash Leverage Command-line tool.
 """
+
 from packaging.version import Version
 
 import click
@@ -27,9 +28,12 @@ def leverage(context, state, verbose):
 
     # if there is a version restriction set, make sure we satisfy it
     config = conf.load()
-    minimum_version = config.get('LEVERAGE_CLI_VERSION')
+    minimum_version = config.get("LEVERAGE_CLI_VERSION")
     if minimum_version and Version(__version__) < Version(minimum_version):
-        click.echo(f"\033[91mWARNING\033[0m\tYour current version ({__version__}) is lower than the required minimum ({minimum_version}).")
+        click.echo(
+            f"\033[91mWARNING\033[0m\tYour current version ({__version__}) is lower than the required minimum ({minimum_version})."
+        )
+
 
 # Add modules to leverage
 leverage.add_command(run)

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -1,12 +1,12 @@
 """
     Binbash Leverage Command-line tool.
 """
-
+import rich
 from packaging.version import Version
 
 import click
 
-from leverage import __version__, conf
+from leverage import __version__, conf, MINIMUM_VERSIONS
 from leverage._internals import pass_state
 from leverage.modules.aws import aws
 from leverage.modules.credentials import credentials
@@ -33,11 +33,14 @@ def leverage(context, state, verbose):
     except NotARepositoryError:
         # restrictions are only verified within a leverage project
         return
-    minimum_version = config.get("LEVERAGE_CLI_VERSION")
-    if minimum_version and Version(__version__) < Version(minimum_version):
-        click.echo(
-            f"\033[91mWARNING\033[0m\tYour current version ({__version__}) is lower than the required minimum ({minimum_version})."
-        )
+
+    # check if the current versions are lower than the minimum required
+    current_values = config.get("TERRAFORM_IMAGE_TAG").split("-")
+    for key, current in zip(MINIMUM_VERSIONS, current_values):
+        if Version(current) < Version(MINIMUM_VERSIONS[key]):
+            rich.print(
+                f"[red]WARNING[/red]\tYour current {key} version ({current}) is lower than the required minimum ({MINIMUM_VERSIONS[key]})."
+            )
 
 
 # Add modules to leverage

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -1,12 +1,12 @@
 """
     Binbash Leverage Command-line tool.
 """
+from packaging.version import Version
 
 import click
 
-from leverage import __version__
+from leverage import __version__, conf
 from leverage._internals import pass_state
-
 from leverage.modules.aws import aws
 from leverage.modules.credentials import credentials
 from leverage.modules import run, project, terraform, tfautomv, kubectl, shell
@@ -25,6 +25,11 @@ def leverage(context, state, verbose):
         # leverage called with no subcommand
         click.echo(context.get_help())
 
+    # if there is a version restriction set, make sure we satisfy it
+    config = conf.load()
+    minimum_version = config.get('LEVERAGE_CLI_VERSION')
+    if minimum_version and Version(__version__) < Version(minimum_version):
+        click.echo(f"\033[91mWARNING\033[0m\tYour current version ({__version__}) is lower than the required minimum ({minimum_version}).")
 
 # Add modules to leverage
 leverage.add_command(run)

--- a/leverage/leverage.py
+++ b/leverage/leverage.py
@@ -11,6 +11,7 @@ from leverage._internals import pass_state
 from leverage.modules.aws import aws
 from leverage.modules.credentials import credentials
 from leverage.modules import run, project, terraform, tfautomv, kubectl, shell
+from leverage.path import NotARepositoryError
 
 
 @click.group(invoke_without_command=True)
@@ -27,7 +28,11 @@ def leverage(context, state, verbose):
         click.echo(context.get_help())
 
     # if there is a version restriction set, make sure we satisfy it
-    config = conf.load()
+    try:
+        config = conf.load()
+    except NotARepositoryError:
+        # restrictions are only verified within a leverage project
+        return
     minimum_version = config.get("LEVERAGE_CLI_VERSION")
     if minimum_version and Version(__version__) < Version(minimum_version):
         click.echo(

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -62,8 +62,10 @@ def test_version_validation():
     Test that we get a warning if we are working with a version lower than the required by the project.
     """
     runner = CliRunner()
-    with mock.patch("leverage.conf.load", return_value={"LEVERAGE_CLI_VERSION": "99.9.9"}):
-        result = runner.invoke(leverage)
+    with mock.patch("leverage.conf.load", return_value={"TERRAFORM_IMAGE_TAG": "1.1.1-2.2.2"}):
+        with mock.patch.dict("leverage.MINIMUM_VERSIONS", {"TERRAFORM": "3.3.3", "LEVERAGE_CLI": "4.4.4"}):
+            result = runner.invoke(leverage)
 
-    assert "is lower than the required minimum (99.9.9)" in result.output
+    assert "Your current TERRAFORM version (1.1.1) is lower than the required minimum (3.3.3)" in result.output.replace("\n", "")
+    assert "Your current LEVERAGE_CLI version (2.2.2) is lower than the required minimum (4.4.4)" in result.output.replace("\n", "")
     assert result.exit_code == 0

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -62,9 +62,11 @@ def test_version_validation():
     Test that we get a warning if we are working with a version lower than the required by the project.
     """
     runner = CliRunner()
-    with mock.patch("leverage.conf.load", return_value={"TERRAFORM_IMAGE_TAG": "1.1.1-2.2.2"}), \
-         mock.patch.dict("leverage.MINIMUM_VERSIONS", {"TERRAFORM": "3.3.3", "LEVERAGE_CLI": "4.4.4"}):
-            result = runner.invoke(leverage)
+    with (
+        mock.patch("leverage.conf.load", return_value={"TERRAFORM_IMAGE_TAG": "1.1.1-2.2.2"}),
+        mock.patch.dict("leverage.MINIMUM_VERSIONS", {"TERRAFORM": "3.3.3", "LEVERAGE_CLI": "4.4.4"}),
+    ):
+        result = runner.invoke(leverage)
 
     assert "Your current TERRAFORM version (1.1.1) is lower than the required minimum (3.3.3)" in result.output.replace(
         "\n", ""

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,7 +1,10 @@
+from unittest import mock
+
 import pytest
+from click.testing import CliRunner
 
+from leverage import leverage
 from leverage.conf import load
-
 
 ROOT_ENV_FILE = """
 # Project settings
@@ -52,3 +55,15 @@ def test_load_config(monkeypatch, click_context, tmp_path, write_files, expected
         loaded_values = load()
 
         assert dict(loaded_values) == expected_values
+
+
+def test_version_validation():
+    """
+    Test that we get a warning if we are working with a version lower than the required by the project.
+    """
+    runner = CliRunner()
+    with mock.patch("leverage.conf.load", return_value={"LEVERAGE_CLI_VERSION": "99.9.9"}):
+        result = runner.invoke(leverage)
+
+    assert "is lower than the required minimum (99.9.9)" in result.output
+    assert result.exit_code == 0

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -71,8 +71,7 @@ def test_version_validation():
     assert "Your current TERRAFORM version (1.1.1) is lower than the required minimum (3.3.3)" in result.output.replace(
         "\n", ""
     )
-    assert (
-        "Your current TOOLBOX version (2.2.2) is lower than the required minimum (4.4.4)"
-        in result.output.replace("\n", "")
+    assert "Your current TOOLBOX version (2.2.2) is lower than the required minimum (4.4.4)" in result.output.replace(
+        "\n", ""
     )
     assert result.exit_code == 0

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -62,10 +62,15 @@ def test_version_validation():
     Test that we get a warning if we are working with a version lower than the required by the project.
     """
     runner = CliRunner()
-    with mock.patch("leverage.conf.load", return_value={"TERRAFORM_IMAGE_TAG": "1.1.1-2.2.2"}):
-        with mock.patch.dict("leverage.MINIMUM_VERSIONS", {"TERRAFORM": "3.3.3", "LEVERAGE_CLI": "4.4.4"}):
+    with mock.patch("leverage.conf.load", return_value={"TERRAFORM_IMAGE_TAG": "1.1.1-2.2.2"}), \
+         mock.patch.dict("leverage.MINIMUM_VERSIONS", {"TERRAFORM": "3.3.3", "LEVERAGE_CLI": "4.4.4"}):
             result = runner.invoke(leverage)
 
-    assert "Your current TERRAFORM version (1.1.1) is lower than the required minimum (3.3.3)" in result.output.replace("\n", "")
-    assert "Your current LEVERAGE_CLI version (2.2.2) is lower than the required minimum (4.4.4)" in result.output.replace("\n", "")
+    assert "Your current TERRAFORM version (1.1.1) is lower than the required minimum (3.3.3)" in result.output.replace(
+        "\n", ""
+    )
+    assert (
+        "Your current LEVERAGE_CLI version (2.2.2) is lower than the required minimum (4.4.4)"
+        in result.output.replace("\n", "")
+    )
     assert result.exit_code == 0

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -64,7 +64,7 @@ def test_version_validation():
     runner = CliRunner()
     with (
         mock.patch("leverage.conf.load", return_value={"TERRAFORM_IMAGE_TAG": "1.1.1-2.2.2"}),
-        mock.patch.dict("leverage.MINIMUM_VERSIONS", {"TERRAFORM": "3.3.3", "LEVERAGE_CLI": "4.4.4"}),
+        mock.patch.dict("leverage.MINIMUM_VERSIONS", {"TERRAFORM": "3.3.3", "TOOLBOX": "4.4.4"}),
     ):
         result = runner.invoke(leverage)
 
@@ -72,7 +72,7 @@ def test_version_validation():
         "\n", ""
     )
     assert (
-        "Your current LEVERAGE_CLI version (2.2.2) is lower than the required minimum (4.4.4)"
+        "Your current TOOLBOX version (2.2.2) is lower than the required minimum (4.4.4)"
         in result.output.replace("\n", "")
     )
     assert result.exit_code == 0


### PR DESCRIPTION
## What?
If you have specified a minimum version at your `build.env` file (`LEVERAGE_CLI_VERSION`), you will get a warning when the currenct CLI version is behind it.

`$ cat build.env`
```
...

# Leverage
LEVERAGE_CLI_VERSION=2.0.0
```

## Why?
Be able to tell what CLI version was used in a given Leverage project.

## References
closes #143 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the CLI tool with version checking functionality that warns users if their installed versions do not meet minimum requirements.
  - Introduced a new dictionary specifying minimum version requirements for "TERRAFORM" and "TOOLBOX".

- **Tests**
  - Added a test to validate the application's behavior when the version is below the required minimum, ensuring proper warning messages are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->