### PR TITLE
[BL-302] Updating url to prevent sso login url deprecation warning

### DIFF
--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -9,7 +9,7 @@ __toolbox_version__ = "1.3.5-0.2.0"
 
 MINIMUM_VERSIONS = {
     "TERRAFORM": "1.3.5",
-    "TOOLBOX": "0.2.1",  # we require awscli >= 2.22 now
+    "TOOLBOX": "0.2.1",  # update to 0.2.1 once released, we require awscli >= 2.22 now
 }
 
 import sys

--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -9,7 +9,7 @@ __toolbox_version__ = "1.3.5-0.2.0"
 
 MINIMUM_VERSIONS = {
     "TERRAFORM": "1.3.5",
-    "TOOLBOX": "0.2.0",
+    "TOOLBOX": "0.2.1",  # we require awscli >= 2.22 now
 }
 
 import sys

--- a/leverage/__init__.py
+++ b/leverage/__init__.py
@@ -9,7 +9,7 @@ __toolbox_version__ = "1.3.5-0.2.0"
 
 MINIMUM_VERSIONS = {
     "TERRAFORM": "1.3.5",
-    "TOOLBOX": "0.2.1",  # update to 0.2.1 once released, we require awscli >= 2.22 now
+    "TOOLBOX": "0.2.4",
 }
 
 import sys

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -365,7 +365,7 @@ class SSOContainer(LeverageContainer):
             # now let's grab the user code from the logs
             user_code = self.get_sso_code(container)
             # with the user code, we can now autocomplete the url
-            link = self.AWS_SSO_LOGIN_URL.format(sso_url=self.paths.common_conf['sso_start_url'], user_code=user_code)
+            link = self.AWS_SSO_LOGIN_URL.format(sso_url=self.paths.common_conf["sso_start_url"], user_code=user_code)
             webbrowser.open_new_tab(link)
             # The SSO code is only valid once: if the browser was able to open it, the fallback link will be invalid
             logger.info(self.FALLBACK_LINK_MSG.format(link=link))

--- a/leverage/container.py
+++ b/leverage/container.py
@@ -314,7 +314,7 @@ class SSOContainer(LeverageContainer):
     AWS_SSO_LOGOUT_SCRIPT = "/home/leverage/scripts/aws-sso/aws-sso-logout.sh"
 
     # SSO constants
-    AWS_SSO_LOGIN_URL = "https://device.sso.{region}.amazonaws.com/?user_code={user_code}"
+    AWS_SSO_LOGIN_URL = "{sso_url}/#/device?user_code={user_code}"
     AWS_SSO_CODE_WAIT_SECONDS = 2
     AWS_SSO_CODE_ATTEMPTS = 10
     FALLBACK_LINK_MSG = "Opening the browser... if it fails, open this link in your browser:\n{link}"
@@ -365,7 +365,7 @@ class SSOContainer(LeverageContainer):
             # now let's grab the user code from the logs
             user_code = self.get_sso_code(container)
             # with the user code, we can now autocomplete the url
-            link = self.AWS_SSO_LOGIN_URL.format(region=region.strip(), user_code=user_code)
+            link = self.AWS_SSO_LOGIN_URL.format(sso_url=self.paths.common_conf['sso_start_url'], user_code=user_code)
             webbrowser.open_new_tab(link)
             # The SSO code is only valid once: if the browser was able to open it, the fallback link will be invalid
             logger.info(self.FALLBACK_LINK_MSG.format(link=link))

--- a/tests/bats/leverage.bats
+++ b/tests/bats/leverage.bats
@@ -37,9 +37,9 @@ teardown(){
 
     run leverage run -l
 
-    assert_line --index 0 "Tasks in build file \`build.py\`:"
-    assert_line --index 1 --regexp "^  hello\s+Say hello.$"
-    assert_line --index 2 --regexp "^Powered by Leverage [0-9]+.[0-9]+.[0-9]+$"
+    assert_line --partial "Tasks in build file \`build.py\`:"
+    assert_line --partial --regexp "^  hello\s+Say hello.$"
+    assert_line --partial --regexp "^Powered by Leverage [0-9]+.[0-9]+.[0-9]+$"
 }
 
 @test "Lists tasks with build script in parent directory" {
@@ -51,9 +51,9 @@ teardown(){
 
     run leverage run -l
 
-    assert_line --index 0 "Tasks in build file \`build.py\`:"
-    assert_line --index 1 --regexp "^  hello\s+Say hello.$"
-    assert_line --index 2 --regexp "^Powered by Leverage [0-9]+.[0-9]+.[0-9]+$"
+    assert_line --partial "Tasks in build file \`build.py\`:"
+    assert_line --partial --regexp "^  hello\s+Say hello.$"
+    assert_line --partial --regexp "^Powered by Leverage [0-9]+.[0-9]+.[0-9]+$"
 }
 
 @test "Simple task runs correctly" {
@@ -66,8 +66,8 @@ teardown(){
     run leverage run hello
 
     assert_output --partial "Hello"
-    assert_line --index 0 --regexp "\[[0-9]+:[0-9]+:[0-9]+\.[0-9]+\] \[ build\.py - ➜ Starting task hello \]"
-    assert_line --index 2 --regexp "\[[0-9]+:[0-9]+:[0-9]+\.[0-9]+\] \[ build\.py - ✔ Completed task hello \]"
+    assert_line --partial --regexp "\[[0-9]+:[0-9]+:[0-9]+\.[0-9]+\] \[ build\.py - ➜ Starting task hello \]"
+    assert_line --partial --regexp "\[[0-9]+:[0-9]+:[0-9]+\.[0-9]+\] \[ build\.py - ✔ Completed task hello \]"
 }
 
 @test "Values are loaded from .env file in current directory" {

--- a/tests/bats/leverage.bats
+++ b/tests/bats/leverage.bats
@@ -38,8 +38,8 @@ teardown(){
     run leverage run -l
 
     assert_line --partial "Tasks in build file \`build.py\`:"
-    assert_line --partial --regexp "^  hello\s+Say hello.$"
-    assert_line --partial --regexp "^Powered by Leverage [0-9]+.[0-9]+.[0-9]+$"
+    assert_line --regexp "hello\s+Say hello."
+    assert_line --regexp "Powered by Leverage [0-9]+.[0-9]+.[0-9]+"
 }
 
 @test "Lists tasks with build script in parent directory" {
@@ -52,8 +52,8 @@ teardown(){
     run leverage run -l
 
     assert_line --partial "Tasks in build file \`build.py\`:"
-    assert_line --partial --regexp "^  hello\s+Say hello.$"
-    assert_line --partial --regexp "^Powered by Leverage [0-9]+.[0-9]+.[0-9]+$"
+    assert_line --regexp "hello\s+Say hello."
+    assert_line --regexp "Powered by Leverage [0-9]+.[0-9]+.[0-9]+"
 }
 
 @test "Simple task runs correctly" {
@@ -66,8 +66,8 @@ teardown(){
     run leverage run hello
 
     assert_output --partial "Hello"
-    assert_line --partial --regexp "\[[0-9]+:[0-9]+:[0-9]+\.[0-9]+\] \[ build\.py - ➜ Starting task hello \]"
-    assert_line --partial --regexp "\[[0-9]+:[0-9]+:[0-9]+\.[0-9]+\] \[ build\.py - ✔ Completed task hello \]"
+    assert_line --regexp "\[[0-9]+:[0-9]+:[0-9]+\.[0-9]+\] \[ build\.py - ➜ Starting task hello \]"
+    assert_line --regexp "\[[0-9]+:[0-9]+:[0-9]+\.[0-9]+\] \[ build\.py - ✔ Completed task hello \]"
 }
 
 @test "Values are loaded from .env file in current directory" {

--- a/tests/test_containers/test_aws.py
+++ b/tests/test_containers/test_aws.py
@@ -50,13 +50,15 @@ def test_sso_login(mocked_new_tab, aws_container, fake_os_user, propagate_logs, 
     """
     Test that we call the correct script and open the correct url.
     """
-    test_link = "https://device.sso.us-east-1.amazonaws.com/?user_code=TEST-CODE"
-    aws_container.sso_login()
+    sso_start_url = "https://test.sso.us-east-1.amazonaws.com"
+    test_link = "https://test.sso.us-east-1.amazonaws.com/#/device?user_code=TEST-CODE"
+    with patch.dict(aws_container.paths.common_conf, {"sso_start_url": sso_start_url}):
+        aws_container.sso_login()
 
     container_args = aws_container.client.api.create_container.call_args_list[0][1]
     # make sure we: point to the correct script
     assert container_args["command"] == "/home/leverage/scripts/aws-sso/aws-sso-login.sh"
     # the browser tab points to the correct code and the correct region
-    assert mocked_new_tab.call_args[0][0] == "https://device.sso.us-east-1.amazonaws.com/?user_code=TEST-CODE"
+    assert mocked_new_tab.call_args[0][0] == test_link
     # and the fallback method is printed
     assert caplog.messages[0] == aws_container.FALLBACK_LINK_MSG.format(link=test_link)


### PR DESCRIPTION
## What?
Using the new url to prevent sso login url deprecation warning.
A new toolbox image must be released first: https://github.com/binbashar/le-docker-leverage-toolbox/pull/72

## Why?
To prevent login url deprecation warnings

## References
https://github.com/binbashar/leverage/issues/302

## Before release

Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated SSO login to use a configurable start URL, allowing for greater flexibility in SSO provider integration.
- **Bug Fixes**
  - Adjusted tests to match the new SSO URL format, ensuring accurate validation of the login process.
- **Chores**
  - Increased the minimum required version for the TOOLBOX component.
- **Tests**
  - Modified test assertions for command output to be less strict about line positions, improving test robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->