### PR TITLE
Implement typed argument casting

### DIFF
--- a/leverage/_casting.py
+++ b/leverage/_casting.py
@@ -1,0 +1,26 @@
+"""
+Value casting utilities.
+"""
+
+from typing import Any
+
+
+def cast_value(value: str) -> Any:
+    """Try to cast a string to bool, int or float.
+
+    Args:
+        value (str): Value to cast.
+
+    Returns:
+        Any: The value converted to its apparent type or the original string.
+    """
+    lowered = value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value

--- a/leverage/_parsing.py
+++ b/leverage/_parsing.py
@@ -2,6 +2,8 @@
     Command line arguments and tasks arguments parsing utilities.
 """
 
+from leverage._casting import cast_value
+
 
 class InvalidArgumentOrderError(RuntimeError):
     pass
@@ -40,13 +42,13 @@ def parse_task_args(arguments):
                     f"Positional argument `{argument}` from task `{{task}}` cannot follow a keyword argument."
                 )
 
-            args.append(argument.strip())
+            args.append(cast_value(argument.strip()))
 
         else:
             key, value = [part.strip() for part in argument.split("=")]
             if key in kwargs:
                 raise DuplicateKeywordArgumentError(f"Duplicated keyword argument `{key}` in task `{{task}}`.")
 
-            kwargs[key] = value
+            kwargs[key] = cast_value(value)
 
     return args, kwargs

--- a/leverage/conf.py
+++ b/leverage/conf.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from yaenv.core import Env
 
+from leverage._casting import cast_value
+
 from leverage import logger
 from leverage.path import get_root_path
 from leverage.path import get_working_path
@@ -56,6 +58,6 @@ def load(config_filename=ENV_CONFIG_FILE):
         config_file = Env(config_file_path)
 
         for key, val in config_file:
-            config_dict[key] = val
+            config_dict[key] = cast_value(val)
 
     return config_dict

--- a/tests/test__parsing.py
+++ b/tests/test__parsing.py
@@ -8,11 +8,11 @@ from leverage._parsing import DuplicateKeywordArgumentError
 @pytest.mark.parametrize(
     "arguments, expected_args, expected_kwargs",
     [
-        ("arg1, arg2, arg3 ", ["arg1", "arg2", "arg3"], {}),  # All positional arguments
+        ("arg1, 2, 3.5 ", ["arg1", 2, 3.5], {}),  # Cast positional arguments
         (  # All keyworded arguments
-            "kwarg1=/val/1,kwarg2 = val2, kwarg3 = val3 ",
+            "kwarg1=true,kwarg2 = val2, kwarg3 = 3 ",
             [],
-            {"kwarg1": "/val/1", "kwarg2": "val2", "kwarg3": "val3"},
+            {"kwarg1": True, "kwarg2": "val2", "kwarg3": 3},
         ),
         ("arg1, arg2, kwarg1=/val/1,kwarg2 = val2", ["arg1", "arg2"], {"kwarg1": "/val/1", "kwarg2": "val2"}),  # Both
         (None, [], {}),  # No arguments

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -30,9 +30,9 @@ CONFIG_PATH=/home/user/.config/
             True,
             {
                 "PROJECT": "foobar",
-                "MFA_ENABLED": "true",
+                "MFA_ENABLED": True,
                 "ENTRYPOINT": "/bin/run",
-                "DEBUG": "true",
+                "DEBUG": True,
                 "CONFIG_PATH": "/home/user/.config/",
             },
         ),


### PR DESCRIPTION
## Summary
- add `cast_value` utility to detect bool/int/float
- cast task parameters and `.env` values to their types
- update tests for new casting behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c005a738832fba0a8e5381fda35d