### PR TITLE
Add automatic credential refresh for AWS SSO

### DIFF
--- a/leverage/modules/auth.py
+++ b/leverage/modules/auth.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from datetime import datetime, timedelta
 from functools import wraps
 from configparser import NoSectionError, NoOptionError
+from typing import Tuple
 
 import boto3
 import click
@@ -54,6 +55,23 @@ def get_layer_profile(raw_profile: str, config_updater: ConfigUpdater, tf_profil
     # if we are processing a profile from a different layer, we need to build it
     layer_profile = layer_profile or f"{project}-{account_name}-{sso_role.lower()}"
 
+    return account_id, account_name, sso_role, layer_profile
+
+
+def _get_sso_profile_from_section(
+    config_updater: ConfigUpdater, profile_section: str, project: str
+) -> Tuple[str, str, str, str]:
+    """
+    Read account_id, account_name, sso_role and build layer_profile from an SSO config section.
+
+    Section name format: "profile <project>-sso-<account_name>".
+    Used by refresh_all_accounts_credentials, where iteration starts from already-known
+    section names rather than profile references parsed from .tf files.
+    """
+    account_name = profile_section.replace(f"profile {project}-sso-", "")
+    account_id = config_updater.get(profile_section, "account_id").value
+    sso_role = config_updater.get(profile_section, "role_name").value
+    layer_profile = f"{project}-{account_name}-{sso_role.lower()}"
     return account_id, account_name, sso_role, layer_profile
 
 
@@ -174,13 +192,16 @@ def check_sso_token(paths: PathsHandler):
         )
 
 
-def refresh_layer_credentials(paths: PathsHandler):
+def refresh_layer_credentials(paths: PathsHandler) -> None:
     tf_profile, raw_profiles = get_profiles(paths)
     config_updater = ConfigUpdater()
     config_updater.read(paths.aws_config_file)
 
     region = config_updater.get(f"profile {paths.project}-sso", "sso_region").value
     client = boto3.client("sso", region_name=region)
+    access_token = _get_sso_token_or_raise(paths)
+    credentials_updater = None  # created lazily on the first profile that needs to be written
+
     for raw in raw_profiles:
         try:
             account_id, account_name, sso_role, layer_profile = get_layer_profile(
@@ -192,65 +213,227 @@ def refresh_layer_credentials(paths: PathsHandler):
         except SkipProfile:
             continue
 
-        # check if credentials need to be renewed
+        if _check_credentials_expiration(config_updater, layer_profile):
+            continue
+
+        if credentials_updater is None:
+            credentials_updater = _get_credentials_updater(paths)
+
+        _retrieve_and_update_credentials(
+            paths=paths,
+            client=client,
+            access_token=access_token,
+            account_id=account_id,
+            sso_role=sso_role,
+            layer_profile=layer_profile,
+            account_name=account_name,
+            config_updater=config_updater,
+            credentials_updater=credentials_updater,
+            raise_on_permission_error=True,
+        )
+
+
+def _check_credentials_expiration(
+    config_updater: ConfigUpdater, layer_profile: str, force_refresh: bool = False
+) -> bool:
+    """
+    Check if credentials need to be renewed based on expiration time.
+
+    Args:
+        config_updater: ConfigUpdater instance with the config file loaded.
+        layer_profile: The layer profile name to check.
+        force_refresh: If True, skip expiration check and return False (needs refresh).
+
+    Returns:
+        bool: True if credentials are still valid and should be skipped, False if they need refresh.
+    """
+    if force_refresh:
+        return False
+
+    try:
+        expiration = int(config_updater.get(f"profile {layer_profile}", "expiration").value) / 1000
+    except (NoSectionError, NoOptionError):
+        # first time using this profile, skip into the credential's retrieval step
+        logger.debug("No cached credentials found.")
+        return False
+
+    # we reduce the validity 30 minutes, to avoid expiration over long-standing tasks
+    renewal = time.time() + (30 * 60)
+    logger.debug(f"Token expiration time: {expiration}")
+    logger.debug(f"Token renewal time: {renewal}")
+    if renewal < expiration:
+        # still valid, nothing to do with this profile!
+        logger.info("Using already configured temporary credentials.")
+        return True
+
+    return False
+
+
+def _get_credentials_updater(paths: PathsHandler) -> ConfigUpdater:
+    """
+    Prepare and return a ConfigUpdater for the credentials file.
+    """
+    paths.aws_credentials_file.touch(exist_ok=True)
+    credentials_updater = ConfigUpdater()
+    credentials_updater.read(paths.aws_credentials_file)
+    return credentials_updater
+
+
+def _retrieve_and_update_credentials(
+    paths: PathsHandler,
+    client,
+    access_token: str,
+    account_id: str,
+    sso_role: str,
+    layer_profile: str,
+    account_name: str,
+    config_updater: ConfigUpdater,
+    credentials_updater: ConfigUpdater,
+    raise_on_permission_error: bool = True,
+) -> bool:
+    """
+    Retrieve credentials from SSO and update both config and credentials files.
+
+    Args:
+        paths: PathsHandler instance.
+        client: boto3 SSO client.
+        access_token: SSO access token.
+        account_id: AWS account ID.
+        sso_role: SSO role name.
+        layer_profile: Layer profile name.
+        account_name: Account name for logging.
+        config_updater: ConfigUpdater instance for config file.
+        credentials_updater: ConfigUpdater instance for credentials file.
+        raise_on_permission_error: If True, raise ExitError on permission errors.
+                                   If False, log warning and return False.
+
+    Returns:
+        bool: True if successful, False if permission error occurred (only when raise_on_permission_error=False).
+
+    Raises:
+        ExitError: If raise_on_permission_error=True and permission error occurs, or for any other ClientError.
+    """
+    logger.debug(f"Retrieving role credentials for {sso_role}...")
+    try:
+        credentials = client.get_role_credentials(
+            roleName=sso_role,
+            accountId=account_id,
+            accessToken=access_token,
+        )["roleCredentials"]
+    except ClientError as error:
+        if error.response["Error"]["Code"] in ("AccessDeniedException", "ForbiddenException"):
+            error_msg = (
+                f"User does not have permission to assume role [bold]{sso_role}[/bold]"
+                " in this account.\nPlease check with your administrator or try"
+                " running [bold]leverage aws configure sso[/bold]."
+            )
+            if raise_on_permission_error:
+                raise ExitError(40, error_msg) from error
+            logger.warning(f"No permission to assume role [bold]{sso_role}[/bold] in {account_name} account. Skipping.")
+            return False
+        raise ExitError(50, f"Error retrieving role credentials: {error}") from error
+
+    # Update expiration on aws/<project>/config
+    logger.info(f"Writing {layer_profile} profile")
+    update_config_section(
+        config_updater,
+        f"profile {layer_profile}",
+        data={
+            "expiration": credentials["expiration"],
+        },
+    )
+
+    # Write credentials on aws/<project>/credentials
+    update_config_section(
+        credentials_updater,
+        layer_profile,
+        data={
+            "aws_access_key_id": credentials["accessKeyId"],
+            "aws_secret_access_key": credentials["secretAccessKey"],
+            "aws_session_token": credentials["sessionToken"],
+        },
+    )
+
+    logger.info(f"Credentials for {account_name} account written successfully.")
+    return True
+
+
+def _get_sso_token_or_raise(paths: PathsHandler) -> str:
+    """Get the SSO access token, or raise a friendly ExitError on failure.
+
+    Wraps file/JSON/key errors so callers (e.g. `leverage aws sso refresh` invoked without
+    a prior `check_sso_token`) get a clear message instead of a raw stacktrace.
+    """
+    try:
+        return get_sso_access_token(paths.sso_token_file)
+    except (OSError, ValueError, KeyError) as e:
+        raise ExitError(1, f"Failed to get SSO access token: {e}") from e
+
+
+def refresh_all_accounts_credentials(paths: PathsHandler, force_refresh: bool = False) -> None:
+    """
+    Refresh credentials for all configured SSO accounts.
+
+    Iterates through every `profile <project>-sso-<account>` section in the AWS config
+    file and refreshes their credentials using the current SSO access token.
+
+    Args:
+        paths: PathsHandler instance with access to project paths and configuration.
+        force_refresh: If True, refresh all credentials regardless of expiration.
+                      If False, only refresh expired credentials.
+    """
+    logger.info("Refreshing credentials for all accounts...")
+
+    config_updater = ConfigUpdater()
+    config_updater.read(paths.aws_config_file)
+    # SSO account profiles use the section name "profile <project>-sso-<account>"; the trailing
+    # dash naturally excludes the parent "profile <project>-sso" section.
+    sso_prefix = f"profile {paths.project}-sso-"
+    sso_profiles = [s for s in config_updater.sections() if s.startswith(sso_prefix)]
+
+    if not sso_profiles:
+        logger.warning("No SSO account profiles found. Run 'leverage aws configure sso' first.")
+        return
+
+    logger.info(f"Found {len(sso_profiles)} account(s) to refresh.")
+    region = config_updater.get(f"profile {paths.project}-sso", "sso_region").value
+    client = boto3.client("sso", region_name=region)
+    access_token = _get_sso_token_or_raise(paths)
+    credentials_updater = _get_credentials_updater(paths)
+
+    refreshed = skipped = failed = 0
+    for profile_section in sso_profiles:
         try:
-            expiration = int(config_updater.get(f"profile {layer_profile}", "expiration").value) / 1000
-        except (NoSectionError, NoOptionError):
-            # first time using this profile, skip into the credential's retrieval step
-            logger.debug("No cached credentials found.")
-        else:
-            # we reduce the validity 30 minutes, to avoid expiration over long-standing tasks
-            renewal = time.time() + (30 * 60)
-            logger.debug(f"Token expiration time: {expiration}")
-            logger.debug(f"Token renewal time: {renewal}")
-            if renewal < expiration:
-                # still valid, nothing to do with these profile!
-                logger.info("Using already configured temporary credentials.")
+            account_id, account_name, sso_role, layer_profile = _get_sso_profile_from_section(
+                config_updater, profile_section, paths.project
+            )
+            if _check_credentials_expiration(config_updater, layer_profile, force_refresh=force_refresh):
+                logger.info(f"Credentials for {account_name} account are still valid, skipping.")
+                skipped += 1
                 continue
 
-        # retrieve credentials
-        logger.debug(f"Retrieving role credentials for {sso_role}...")
-        try:
-            credentials = client.get_role_credentials(
-                roleName=sso_role,
-                accountId=account_id,
-                accessToken=get_sso_access_token(paths.sso_token_file),
-            )["roleCredentials"]
-        except ClientError as error:
-            if error.response["Error"]["Code"] in ("AccessDeniedException", "ForbiddenException"):
-                raise ExitError(
-                    40,
-                    f"User does not have permission to assume role [bold]{sso_role}[/bold]"
-                    " in this account.\nPlease check with your administrator or try"
-                    " running [bold]leverage aws configure sso[/bold].",
-                )
+            logger.info(f"Retrieving credentials for {account_name} account...")
+            if _retrieve_and_update_credentials(
+                paths=paths,
+                client=client,
+                access_token=access_token,
+                account_id=account_id,
+                sso_role=sso_role,
+                layer_profile=layer_profile,
+                account_name=account_name,
+                config_updater=config_updater,
+                credentials_updater=credentials_updater,
+                raise_on_permission_error=False,
+            ):
+                logger.info(f"Credentials for {account_name} account refreshed successfully.")
+                refreshed += 1
             else:
-                raise ExitError(50, f"Error retrieving role credentials: {error}")
+                failed += 1
+        except Exception as e:
+            logger.exception(f"Failed to refresh credentials for {profile_section}: {e}")
+            failed += 1
 
-        # update expiration on aws/<project>/config
-        logger.info(f"Writing {layer_profile} profile")
-        update_config_section(
-            config_updater,
-            f"profile {layer_profile}",
-            data={
-                "expiration": credentials["expiration"],
-            },
-        )
-        # write credentials on aws/<project>/credentials (create the file if it doesn't exist first)
-        paths.aws_credentials_file.touch(exist_ok=True)
-        credentials_updater = ConfigUpdater()
-        credentials_updater.read(paths.aws_credentials_file)
-
-        update_config_section(
-            credentials_updater,
-            layer_profile,
-            data={
-                "aws_access_key_id": credentials["accessKeyId"],
-                "aws_secret_access_key": credentials["secretAccessKey"],
-                "aws_session_token": credentials["sessionToken"],
-            },
-        )
-        logger.info(f"Credentials for {account_name} account written successfully.")
+    logger.info(f"Credential refresh complete: {refreshed} refreshed, {skipped} skipped, {failed} failed.")
 
 
 def refresh_layer_credentials_mfa(paths: PathsHandler):

--- a/leverage/modules/aws.py
+++ b/leverage/modules/aws.py
@@ -15,7 +15,7 @@ from leverage.modules.runner import Runner
 from leverage.modules.utils import _handle_subcommand
 from leverage._utils import get_or_create_section, ExitError
 from leverage._internals import pass_state, pass_runner, pass_paths
-from leverage.modules.auth import get_sso_access_token
+from leverage.modules.auth import get_sso_access_token, refresh_all_accounts_credentials
 from leverage.modules.auth import _perform_authentication as perform_authentication
 
 
@@ -217,9 +217,15 @@ def sso(context: click.Context, awscli: Runner, args: Tuple[str, ...]) -> None:
 
 
 @sso.command()
+@click.option(
+    "--refresh-all",
+    is_flag=True,
+    default=False,
+    help="Automatically refresh credentials for all configured accounts after login.",
+)
 @pass_paths
 @pass_runner
-def login(awscli: Runner, paths: PathsHandler) -> None:
+def login(awscli: Runner, paths: PathsHandler, refresh_all: bool) -> None:
     """Login"""
     exit_code, region, _ = awscli.exec("configure", "get", "sso_region", "--profile", f"{paths.project}-sso")
     if exit_code:
@@ -298,6 +304,22 @@ def login(awscli: Runner, paths: PathsHandler) -> None:
     token_file.write_text(json.dumps(token))
 
     logger.info(f"Successfully logged in!.")
+
+    if refresh_all:
+        refresh_all_accounts_credentials(paths, force_refresh=False)
+
+
+@sso.command()
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Force refresh all credentials, even if they haven't expired.",
+)
+@pass_paths
+def refresh(paths: PathsHandler, force: bool) -> None:
+    """Refresh credentials for all configured accounts"""
+    refresh_all_accounts_credentials(paths, force_refresh=force)
 
 
 @sso.command()

--- a/leverage/modules/utils.py
+++ b/leverage/modules/utils.py
@@ -24,7 +24,13 @@ def _handle_subcommand(
     Raises:
         Exit: Whenever runner execution returns a non-zero exit code
     """
-    caller_pos = args.index(caller_name) if caller_name is not None else 0
+    # When this function is called from a click subcommand callback (e.g. the `sso` group),
+    # `args` is the subcontext's args slice and no longer contains the caller's own name. Treat
+    # that as "search from the start" rather than crashing on ValueError.
+    try:
+        caller_pos = args.index(caller_name) if caller_name is not None else 0
+    except ValueError:
+        caller_pos = 0
 
     # Find if one of the wrapped subcommand was invoked
     wrapped_subcommands = context.command.commands.keys()
@@ -38,12 +44,15 @@ def _handle_subcommand(
         raise Exit(exit_code)
 
     subcommand = context.command.commands.get(subcommand)
-    # Check that the subcommand arguments are valid
-    subcommand.make_context(
-        info_name=subcommand.name, args=list(args)[args.index(subcommand.name) + 1 :], parent=context
+    # Build the subcommand's own context from its slice of the CLI args and invoke it through that
+    # context. We can't use context.invoke / context.forward here: invoke ignores user-supplied
+    # options (everything falls back to defaults) and forward copies the parent group's params
+    # (notably `args`) into the child callback's kwargs, which raises TypeError as soon as the
+    # child has its own click options (e.g. `sso login --refresh-all`, `sso refresh --force`).
+    sub_ctx = subcommand.make_context(
+        info_name=subcommand.name,
+        args=list(args)[args.index(subcommand.name) + 1 :],
+        parent=context,
     )
-    # Invoke wrapped command
-    if not subcommand.params:
-        context.invoke(subcommand)
-    else:
-        context.forward(subcommand)
+    with sub_ctx:
+        sub_ctx.command.invoke(sub_ctx)

--- a/tests/test_modules/test_auth.py
+++ b/tests/test_modules/test_auth.py
@@ -1,36 +1,56 @@
 from collections import namedtuple
 from pathlib import PosixPath
 from unittest import mock
-from unittest.mock import Mock, MagicMock, PropertyMock
+from unittest.mock import Mock, MagicMock
 
 import pytest
 from botocore.exceptions import ClientError
 from configupdater import ConfigUpdater
 
+from leverage import leverage
 from leverage._utils import ExitError
-from leverage.container import SSOContainer
-from leverage.modules.auth import refresh_layer_credentials, get_layer_profile, SkipProfile
+from leverage.path import PathsHandler
+from leverage.modules.auth import (
+    refresh_layer_credentials,
+    get_layer_profile,
+    SkipProfile,
+    refresh_all_accounts_credentials,
+)
 from leverage.modules.aws import get_account_roles, add_sso_profile, configure_sso_profiles
-from tests.test_containers import container_fixture_factory
 
 
 @pytest.fixture
-def sso_container(with_click_context, propagate_logs):
-    mocked_cont = container_fixture_factory(SSOContainer)
-    mocked_cont.get_sso_access_token = Mock(return_value="testing-token")
+def paths(with_click_context, propagate_logs):
+    """
+    Mock PathsHandler used by auth.py functions.
 
-    # mock PathsHandler with a named tuple?
-    with mock.patch(
-        "leverage.container.PathsHandler.local_backend_tfvars",
-        new_callable=PropertyMock(return_value=PosixPath("~/config/backend.tfvars")),
-    ), mock.patch(
-        "leverage.container.PathsHandler.host_aws_profiles_file",
-        new_callable=PropertyMock(return_value="~/.aws/test/config"),
-    ), mock.patch(
-        "leverage.container.PathsHandler.host_aws_credentials_file",
-        new_callable=PropertyMock(return_value="~/.aws/test/credentials"),
+    Backed by a MagicMock(spec=PathsHandler) so unexpected attribute access fails loudly. Path-like
+    attributes are real PosixPath instances so the patched `pathlib.Path.read_text` and
+    `configupdater.parser.open` side effects in the tests can resolve files via `data_dict`.
+    """
+    mocked = MagicMock(spec=PathsHandler)
+    mocked.project = "test"
+    mocked.project_long = "binbash-test"
+    mocked.aws_config_file = PosixPath("~/.aws/test/config")
+    mocked.aws_credentials_file = PosixPath("~/.aws/test/credentials")
+    mocked.backend_tfvars = PosixPath("~/config/backend.tfvars")
+    mocked.cwd = PosixPath("~/some/layer")
+    mocked.sso_cache = PosixPath("~/.aws/test/sso/cache")
+    mocked.sso_token_file = PosixPath("~/.aws/test/sso/cache/token")
+    return mocked
+
+
+@pytest.fixture
+def mock_sso_token():
+    """Mock get_sso_access_token() to return a fixed token without touching disk.
+
+    Patches both bindings (auth.py defines it, aws.py imports it) so any caller in either
+    module hits the same fake.
+    """
+    with mock.patch("leverage.modules.auth.get_sso_access_token", return_value="testing-token") as m, mock.patch(
+        "leverage.modules.aws.get_sso_access_token", return_value="testing-token"
     ):
-        yield mocked_cont
+        yield m
 
 
 ACC_ROLES = {
@@ -85,11 +105,11 @@ mocked_updater.__getitem__.return_value = {
 
 
 @mock.patch("boto3.client")
-def test_configure_sso_profiles(mocked_boto, sso_container):
+def test_configure_sso_profiles(mocked_boto, paths, mock_sso_token):
     with mock.patch("leverage.modules.aws.ConfigUpdater.__new__", return_value=mocked_updater):
         with mock.patch("leverage.modules.aws.get_account_roles", return_value=ACC_ROLES):
             with mock.patch("leverage.modules.aws.add_sso_profile") as mocked_add_profile:
-                configure_sso_profiles(sso_container)
+                configure_sso_profiles(paths)
 
     # 2 profiles were added
     assert mocked_add_profile.call_args_list[0].args[1:] == (
@@ -202,15 +222,21 @@ data_dict = {
 def read_text_side_effect(self: PosixPath, *args, **kwargs):
     """
     Every time we call read_text(), this side effect will try to get the value from data_dict rather than reading a disk file.
+    Raises FileNotFoundError for unknown files so the caller's `except FileNotFoundError`
+    paths (e.g. optional tf files in get_profiles) work as expected.
     """
-    return data_dict[self.name]
+    try:
+        return data_dict[self.name]
+    except KeyError:
+        raise FileNotFoundError(self.name)
 
 
-def open_side_effect(name: PosixPath, *args, **kwargs):
+def open_side_effect(name, *args, **kwargs):
     """
     Every time we call open(), this side effect will try to get the value from data_dict rather than reading a disk file.
+    Accepts either a string or PosixPath for `name`.
     """
-    return mock.mock_open(read_data=data_dict[name])()
+    return mock.mock_open(read_data=data_dict.get(str(name), data_dict.get(name, "")))()
 
 
 b3_client = Mock()
@@ -232,13 +258,13 @@ b3_client.get_role_credentials = Mock(
 @mock.patch("pathlib.Path.touch", new=Mock())
 @mock.patch("boto3.client", return_value=b3_client)
 @mock.patch("configupdater.parser.open", side_effect=open_side_effect)
-def test_refresh_layer_credentials_first_time(mock_open, mock_boto, sso_container, caplog):
-    refresh_layer_credentials(sso_container)
+def test_refresh_layer_credentials_first_time(mock_open, mock_boto, paths, mock_sso_token, caplog):
+    refresh_layer_credentials(paths)
 
     # there was no previous profile set for the layer
-    assert caplog.messages[1] == "No cached credentials found."
+    assert "No cached credentials found." in caplog.messages
     # so we retrieve it
-    assert caplog.messages[2] == "Retrieving role credentials for devops..."
+    assert "Retrieving role credentials for devops..." in caplog.messages
 
 
 @mock.patch("leverage.modules.auth.get_profiles", new=Mock(return_value=("test-valid-devops", ["test-valid-profile"])))
@@ -247,13 +273,13 @@ def test_refresh_layer_credentials_first_time(mock_open, mock_boto, sso_containe
 @mock.patch("time.time", new=Mock(return_value=NOW_EPOCH))
 @mock.patch("boto3.client", return_value=b3_client)
 @mock.patch("configupdater.parser.open", side_effect=open_side_effect)
-def test_refresh_layer_credentials_still_valid(mock_open, mock_boto, sso_container, caplog):
-    refresh_layer_credentials(sso_container)
+def test_refresh_layer_credentials_still_valid(mock_open, mock_boto, paths, mock_sso_token, caplog):
+    refresh_layer_credentials(paths)
 
-    assert caplog.messages[1] == f"Token expiration time: 170600900.0"
-    assert caplog.messages[2] == f"Token renewal time: 170501800"  # NOW_EPOCH - 30*60
+    assert "Token expiration time: 170600900.0" in caplog.messages
+    assert "Token renewal time: 170501800" in caplog.messages  # NOW_EPOCH + 30*60
     # renewal is less than expiration, so our credentials are still fine
-    assert caplog.messages[3] == "Using already configured temporary credentials."
+    assert "Using already configured temporary credentials." in caplog.messages
 
 
 @mock.patch("leverage.modules.auth.update_config_section")
@@ -262,8 +288,8 @@ def test_refresh_layer_credentials_still_valid(mock_open, mock_boto, sso_contain
 @mock.patch("time.time", new=Mock(return_value=1705859000))
 @mock.patch("boto3.client", return_value=b3_client)
 @mock.patch("configupdater.parser.open", side_effect=open_side_effect)
-def test_refresh_layer_credentials(mock_open, mock_boto, mock_update_conf, sso_container, propagate_logs):
-    refresh_layer_credentials(sso_container)
+def test_refresh_layer_credentials(mock_open, mock_boto, mock_update_conf, paths, mock_sso_token, propagate_logs):
+    refresh_layer_credentials(paths)
 
     # the expiration was set
     assert mock_update_conf.call_args_list[0].args[1] == "profile test-apps-devstg-devops"
@@ -289,11 +315,305 @@ def test_refresh_layer_credentials(mock_open, mock_boto, mock_update_conf, sso_c
         ClientError({"Error": {"Code": "ForbiddenException", "Message": "No access"}}, "GetRoleCredentials"),
     ],
 )
-def test_refresh_layer_credentials_no_access(mock_open, mock_update_conf, sso_container, error):
+def test_refresh_layer_credentials_no_access(mock_open, mock_update_conf, paths, mock_sso_token, error):
     with mock.patch("boto3.client") as mocked_client:
         mocked_client_obj = MagicMock()
         mocked_client_obj.get_role_credentials.side_effect = error
         mocked_client.return_value = mocked_client_obj
 
         with pytest.raises(ExitError):
-            refresh_layer_credentials(sso_container)
+            refresh_layer_credentials(paths)
+
+
+# Tests for refresh_all_accounts_credentials
+
+
+FILE_AWS_CONFIG_MULTI_ACCOUNTS = """
+[profile test-sso]
+sso_region = us-test-1
+
+[profile test-sso-security]
+account_id = 123456
+role_name = DevOps
+
+[profile test-sso-shared]
+account_id = 234567
+role_name = DevOps
+
+[profile test-sso-network]
+account_id = 345678
+role_name = DevOps
+
+[profile test-security-devops]
+expiration=1705859470
+
+[profile test-shared-devops]
+expiration=170600900000
+
+[profile test-network-devops]
+"""
+
+data_dict_multi = {
+    "~/.aws/test/config": FILE_AWS_CONFIG_MULTI_ACCOUNTS,
+    "~/.aws/test/credentials": "",
+}
+
+
+def open_side_effect_multi(name: PosixPath, *_args, **_kwargs):
+    """
+    Side effect for opening multi-account config files.
+    """
+    file_content = data_dict_multi.get(str(name), data_dict_multi.get(name, ""))
+    return mock.mock_open(read_data=file_content)()
+
+
+b3_client_multi = Mock()
+b3_client_multi.get_role_credentials = Mock(
+    return_value={
+        "roleCredentials": {
+            "expiration": "1705859500",
+            "accessKeyId": "new-access-key",
+            "secretAccessKey": "new-secret-key",
+            "sessionToken": "new-session-token",
+        }
+    }
+)
+
+
+@mock.patch("leverage.modules.auth.update_config_section")
+@mock.patch("pathlib.Path.touch", new=Mock())
+@mock.patch("time.time", new=Mock(return_value=NOW_EPOCH))
+@mock.patch("boto3.client", return_value=b3_client_multi)
+@mock.patch("configupdater.parser.open", side_effect=open_side_effect_multi)
+def test_refresh_all_accounts_credentials_success(
+    _mock_open, _mock_boto, _mock_update_conf, paths, mock_sso_token, caplog
+):
+    """
+    Test successful credential refresh for multiple accounts with smart expiration checking.
+
+    Verifies:
+    1. The function correctly identifies SSO profiles from the config file.
+    2. It skips accounts with valid (non-expired) credentials when force_refresh=False.
+    3. It refreshes credentials for accounts that need renewal.
+    4. It provides clear progress logging for each account.
+    5. It returns a summary of successful vs failed operations.
+    """
+    refresh_all_accounts_credentials(paths, force_refresh=False)
+
+    assert "Refreshing credentials for all accounts..." in caplog.text
+    assert "Found 3 account(s) to refresh." in caplog.text
+
+    assert "Retrieving credentials for security account..." in caplog.text
+    assert "Credentials for security account refreshed successfully" in caplog.text
+    assert "Retrieving credentials for network account..." in caplog.text
+    assert "Credentials for network account refreshed successfully" in caplog.text
+
+    assert "Credentials for shared account are still valid, skipping." in caplog.text
+
+    assert "Credential refresh complete: 2 refreshed, 1 skipped, 0 failed." in caplog.text
+
+
+@mock.patch("pathlib.Path.touch", new=Mock())
+@mock.patch("boto3.client", return_value=b3_client_multi)
+@mock.patch("configupdater.parser.open", side_effect=open_side_effect_multi)
+def test_refresh_all_accounts_credentials_force_refresh(_mock_open, _mock_boto, paths, mock_sso_token, caplog):
+    """
+    Test that force_refresh=True bypasses expiration checks and refreshes all credentials.
+    """
+    with mock.patch("leverage.modules.auth.update_config_section"):
+        refresh_all_accounts_credentials(paths, force_refresh=True)
+
+    assert "Retrieving credentials for security account..." in caplog.text
+    assert "Retrieving credentials for shared account..." in caplog.text
+    assert "Retrieving credentials for network account..." in caplog.text
+
+    assert "are still valid, skipping" not in caplog.text
+
+
+FILE_AWS_CONFIG_NO_SSO_PROFILES = """
+[profile test-sso]
+sso_region = us-test-1
+"""
+
+data_dict_no_profiles = {
+    "~/.aws/test/config": FILE_AWS_CONFIG_NO_SSO_PROFILES,
+    "~/.aws/test/credentials": "",
+}
+
+
+def open_side_effect_no_profiles(name: PosixPath, *_args, **_kwargs):
+    """
+    Side effect for opening config with no SSO profiles.
+    """
+    file_content = data_dict_no_profiles.get(str(name), data_dict_no_profiles.get(name, ""))
+    return mock.mock_open(read_data=file_content)()
+
+
+@mock.patch("pathlib.Path.touch", new=Mock())
+@mock.patch("boto3.client", return_value=b3_client_multi)
+@mock.patch("configupdater.parser.open", side_effect=open_side_effect_no_profiles)
+def test_refresh_all_accounts_credentials_no_profiles(_mock_open, _mock_boto, paths, mock_sso_token, caplog):
+    """
+    Test graceful handling when no SSO account profiles are configured.
+    """
+    refresh_all_accounts_credentials(paths, force_refresh=False)
+
+    assert "No SSO account profiles found" in caplog.text
+
+
+@mock.patch("leverage.modules.auth.update_config_section")
+@mock.patch("pathlib.Path.touch", new=Mock())
+@mock.patch("time.time", new=Mock(return_value=NOW_EPOCH))
+@mock.patch("configupdater.parser.open", side_effect=open_side_effect_multi)
+def test_refresh_all_accounts_credentials_permission_error(
+    _mock_open, _mock_update_conf, paths, mock_sso_token, caplog
+):
+    """
+    Test graceful handling of permission errors for specific accounts while continuing with others.
+    """
+    with mock.patch("boto3.client") as mocked_client:
+        mocked_client_obj = MagicMock()
+        # First call succeeds, second call fails with permission error, third call succeeds
+        mocked_client_obj.get_role_credentials.side_effect = [
+            {
+                "roleCredentials": {
+                    "expiration": "1705859500",
+                    "accessKeyId": "access-key",
+                    "secretAccessKey": "secret-key",
+                    "sessionToken": "session-token",
+                }
+            },
+            ClientError({"Error": {"Code": "AccessDeniedException", "Message": "No access"}}, "GetRoleCredentials"),
+            {
+                "roleCredentials": {
+                    "expiration": "1705859500",
+                    "accessKeyId": "access-key",
+                    "secretAccessKey": "secret-key",
+                    "sessionToken": "session-token",
+                }
+            },
+        ]
+        mocked_client.return_value = mocked_client_obj
+
+        refresh_all_accounts_credentials(paths, force_refresh=True)
+
+    assert "No permission to assume role" in caplog.text
+    assert "Skipping." in caplog.text
+
+    assert "Credential refresh complete: 2 refreshed, 0 skipped, 1 failed." in caplog.text
+
+
+@mock.patch("pathlib.Path.touch", new=Mock())
+@mock.patch("configupdater.parser.open", side_effect=open_side_effect_multi)
+def test_refresh_all_accounts_credentials_token_error(_mock_open, paths):
+    """
+    Test that the function properly handles SSO access token retrieval failures.
+    """
+    with mock.patch("leverage.modules.auth.get_sso_access_token", side_effect=FileNotFoundError("Token not found")):
+        with mock.patch("boto3.client", return_value=b3_client_multi):
+            with pytest.raises(ExitError, match="Failed to get SSO access token"):
+                refresh_all_accounts_credentials(paths, force_refresh=False)
+
+
+@mock.patch("leverage.modules.auth.update_config_section")
+@mock.patch("pathlib.Path.touch", new=Mock())
+@mock.patch("time.time", new=Mock(return_value=NOW_EPOCH))
+@mock.patch("boto3.client", return_value=b3_client_multi)
+@mock.patch("configupdater.parser.open", side_effect=open_side_effect_multi)
+def test_refresh_all_accounts_credentials_calls_update_correctly(
+    _mock_open, _mock_boto, mock_update_conf, paths, mock_sso_token
+):
+    """
+    Test that the function correctly updates both AWS config and credentials files with proper data.
+    """
+    refresh_all_accounts_credentials(paths, force_refresh=True)
+
+    # 3 accounts with force_refresh => 6 calls (config + credentials for each)
+    assert mock_update_conf.call_count == 6
+
+    profile_calls = [call.args[1] for call in mock_update_conf.call_args_list]
+    assert "profile test-security-devops" in profile_calls
+    assert "test-security-devops" in profile_calls
+    assert "profile test-shared-devops" in profile_calls
+    assert "test-shared-devops" in profile_calls
+    assert "profile test-network-devops" in profile_calls
+    assert "test-network-devops" in profile_calls
+
+
+# Integration-style test with real file operations
+def test_refresh_all_accounts_credentials_integration(tmp_path, paths, mock_sso_token, caplog):
+    """
+    Integration test using real file operations to verify end-to-end functionality.
+    """
+    # Create real temporary files
+    config_file = tmp_path / "config"
+    credentials_file = tmp_path / "credentials"
+
+    config_content = """[profile test-sso]
+sso_region = us-test-1
+
+[profile test-sso-security]
+account_id = 123456
+role_name = DevOps
+
+[profile test-sso-shared]
+account_id = 234567
+role_name = DevOps
+
+[profile test-security-devops]
+expiration=170600900000
+"""
+    config_file.write_text(config_content)
+    credentials_file.write_text("")
+
+    # Point the mocked PathsHandler at the real files
+    paths.aws_config_file = config_file
+    paths.aws_credentials_file = credentials_file
+
+    with mock.patch("time.time", return_value=NOW_EPOCH):
+        with mock.patch("boto3.client", return_value=b3_client_multi):
+            with mock.patch("leverage.modules.auth.update_config_section") as mock_update:
+                refresh_all_accounts_credentials(paths, force_refresh=False)
+
+    # Security account should be skipped (valid credentials), shared account should be refreshed
+    assert mock_update.call_count == 2  # 1 account refreshed (config + credentials)
+
+    profile_calls = [call.args[1] for call in mock_update.call_args_list]
+    assert "profile test-shared-devops" in profile_calls
+    assert "test-shared-devops" in profile_calls
+
+    assert "Found 2 account(s) to refresh." in caplog.text
+    assert "Credentials for security account are still valid, skipping." in caplog.text
+    assert "Retrieving credentials for shared account..." in caplog.text
+    assert "Credentials for shared account refreshed successfully." in caplog.text
+
+
+# CLI-level regression tests for the click subcommand dispatch path.
+#
+# Before the fix in `leverage.modules.utils._handle_subcommand`, invoking any sso subcommand
+# that declared its own click options (e.g. `aws sso login --refresh-all`, `aws sso refresh
+# [--force]`) crashed with `TypeError: <cmd>() got an unexpected keyword argument 'args'`
+# because `context.forward(subcommand)` was copying the parent group's `args` parameter into
+# the child callback's kwargs.
+
+
+def test_aws_sso_refresh_invokes_refresh_all_accounts(leverage_project, leverage_runner):
+    """`leverage aws sso refresh` reaches refresh_all_accounts_credentials with force_refresh=False."""
+    with leverage_runner(leverage_project) as runner:
+        with mock.patch("leverage.modules.aws.refresh_all_accounts_credentials") as mock_refresh:
+            result = runner.invoke(leverage, ["aws", "sso", "refresh"])
+
+    assert result.exit_code == 0, result.output + (str(result.exception) if result.exception else "")
+    mock_refresh.assert_called_once()
+    assert mock_refresh.call_args.kwargs == {"force_refresh": False}
+
+
+def test_aws_sso_refresh_force_invokes_refresh_all_accounts(leverage_project, leverage_runner):
+    """`leverage aws sso refresh --force` forwards force_refresh=True."""
+    with leverage_runner(leverage_project) as runner:
+        with mock.patch("leverage.modules.aws.refresh_all_accounts_credentials") as mock_refresh:
+            result = runner.invoke(leverage, ["aws", "sso", "refresh", "--force"])
+
+    assert result.exit_code == 0, result.output + (str(result.exception) if result.exception else "")
+    mock_refresh.assert_called_once()
+    assert mock_refresh.call_args.kwargs == {"force_refresh": True}


### PR DESCRIPTION
# Add Automatic Credential Refresh for AWS SSO

## What?

### New Features
* **Automatic refresh**: `--refresh-all` flag on `leverage aws sso login` to refresh all account credentials after SSO login
* **Manual refresh**: New `leverage aws sso refresh [--force]` command
* **Smart renewal**: Skips valid credentials (>30 min remaining) unless `--force` specified
* **Error handling**: Continues on permission errors, provides success/failure summary

### Infrastructure Fixes
* Fixed Click option parsing in `_handle_subcommand()` for nested commands
* Fixed `--help` and `help` syntaxes for all wrapped Python commands
* Fixed args propagation using `inspect.signature()`

### Tests
* 8 new unit tests (94% coverage) + 1 integration test with real file I/O
* All edge cases covered: success, errors, force refresh, missing profiles

## Why?

Currently, after SSO login, you need to manually refresh credentials for each AWS account. Often this means running `terraform plan` or `terraform output` just to trigger credential refresh - even when you only want to generate a kubeconfig for EKS or run a simple AWS CLI command. This is time-consuming and annoying.

This PR streamlines the workflow with automatic or one-command refresh that skips accounts with valid credentials.

**Benefits**: Time savings, better UX, no unnecessary Terraform operations, graceful error handling, backward compatible (opt-in)

## Usage

```bash
# Auto-refresh on login
leverage aws sso login --refresh-all

# Manual refresh (smart - skips valid credentials)
leverage aws sso refresh

# Force refresh all
leverage aws sso refresh --force

# Help works both ways now
leverage aws sso refresh --help
leverage aws sso refresh help
```

## Testing

```bash
leverage aws sso login --refresh-all    # Test auto-refresh
leverage aws sso refresh                # Test smart refresh
leverage aws sso refresh --force        # Test force refresh
leverage aws sso refresh --help         # Verify help works
```

## Before Release

Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk refresh for all configured SSO accounts via a new refresh action
  * `--refresh-all` flag on SSO login and a new `sso refresh` command
  * `--force` option to override expiration checks and force refresh

* **Improvements**
  * Smart expiration handling with a 30-minute renewal window to avoid unnecessary refreshes
  * Lazy updater usage, per-account progress, granular permission/error reporting and a final summary
  * More robust command/subcommand help and invocation behavior

* **Tests**
  * Comprehensive tests for multi-account, force, permission/error, and end-to-end flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->